### PR TITLE
Fixed image viewer crash on Python 3.7 (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.3.1] - 2022-05-04
+### Fixed
+- [cli,tui] Fixed image viewer crash on Python 3.7.
+
+
 ## [0.3.0] - 2022-04-26
 ### Fixed
 - [lib] Fixed the *scroll* parameter of `TermImage.draw()` ([#29](https://github.com/AnonymouX47/term-image/pull/29)).
@@ -111,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First official release
 
 
-[Unreleased]: https://github.com/AnonymouX47/term-image/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/AnonymouX47/term-image/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/AnonymouX47/term-image/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/AnonymouX47/term-image/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/AnonymouX47/term-image/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/AnonymouX47/term-image/releases/tag/v0.1.1

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1246,18 +1246,21 @@ logger = _logging.getLogger(__name__)
 # Will be updated from `.logging.init_log()` if multiprocessing is enabled
 interrupted: Union[None, Event, mp_Event] = None
 
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
 # Used by `check_dir()`
-_depth: int = None
+_depth = None  #: int
 
 # Set from within `check_dirs()`; Hence, only set in "Checker-?" processes
-_dir_queue: Union[None, Queue, mp_Queue] = None
-_free_checkers: Optional[Value] = None
-_source: Optional[str] = None
+_dir_queue = None  #: Union[None, Queue, mp_Queue]
+_free_checkers = None  #: Optional[Value]
+_source = None  #: Optional[str]
 
 # Set from within `main()`
-MAX_DEPTH: Optional[int] = None
-RECURSIVE: Optional[bool] = None
-SHOW_HIDDEN: Optional[bool] = None
+MAX_DEPTH = None  #: Optional[int]
+RECURSIVE = None  #: Optional[bool]
+SHOW_HIDDEN = None  #: Optional[bool]
 # # Used in other modules
-args: Optional[argparse.Namespace] = None
-url_images: Optional[list] = None
+args = None  #: Optional[argparse.Namespace]
+url_images = None  #: Optional[list]

--- a/term_image/logging.py
+++ b/term_image/logging.py
@@ -219,9 +219,12 @@ if stacklevel_is_available:
 else:
     _kwargs = _kwargs_exc = {}
 
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
 # Set from within `init_log()`
-DEBUG: Optional[bool] = None
-MULTI: Optional[bool] = None
-QUIET: Optional[bool] = None
-VERBOSE: Optional[bool] = None
-VERBOSE_LOG: Optional[bool] = None
+DEBUG = None  #: Optional[bool]
+MULTI = None  #: Optional[bool]
+QUIET = None  #: Optional[bool]
+VERBOSE = None  #: Optional[bool]
+VERBOSE_LOG = None  #: Optional[bool]

--- a/term_image/logging_multi.py
+++ b/term_image/logging_multi.py
@@ -6,7 +6,6 @@ import logging as _logging
 import os
 from multiprocessing import JoinableQueue, Process
 from traceback import format_exception
-from typing import Optional
 
 from . import cli, logging, notify
 
@@ -129,5 +128,8 @@ LOG = 0
 NOTIF = 1
 child_processes = []
 
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
 # Set from `process_multi_logs()` in the MultiLogger thread, only in the main process
-log_queue: Optional[JoinableQueue] = None
+log_queue = None  #: Optional[JoinableQueue]

--- a/term_image/tui/keys.py
+++ b/term_image/tui/keys.py
@@ -8,7 +8,7 @@ from os.path import abspath, basename
 from shutil import get_terminal_size
 from time import sleep
 from types import FunctionType
-from typing import Any, Optional, Tuple
+from typing import Tuple
 
 import urwid
 
@@ -665,9 +665,12 @@ key_bar_is_collapsed = True
 expand_key_is_shown = True
 no_globals = {"global", "confirmation", "full-grid-image", "overlay"}
 
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
 # Use in the "confirmation" context. Set by `set_confirmation()`
-_confirm: Optional[Tuple[FunctionType, Tuple[Any]]] = None
-_cancel: Optional[Tuple[FunctionType, Tuple[Any]]] = None
+_confirm = None  #: Optional[Tuple[FunctionType, Tuple[Any]]]
+_cancel = None  #: Optional[Tuple[FunctionType, Tuple[Any]]]
 
 # Used for overlays
-_prev_view_widget: Optional[urwid.Widget] = None
+_prev_view_widget = None  #: Optional[urwid.Widget]

--- a/term_image/tui/main.py
+++ b/term_image/tui/main.py
@@ -699,9 +699,14 @@ grid_active = Event()
 grid_change = Event()
 grid_scan_done = Event()
 next_grid = Queue(1)
-_grid_list: Optional[list] = None
-grid_path: Optional[str] = None
-last_non_empty_grid_path: Optional[str] = None
+
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
+# # Set from within `display_images()`
+_grid_list = None  #: Optional[list]
+grid_path = None  #: Optional[str]
+last_non_empty_grid_path = None  #: Optional[str]
 
 # For menu scanning/listing
 menu_acknowledge = Event()
@@ -725,9 +730,12 @@ UNREADABLE = 1
 IMAGE = 2
 DIR = 3
 
+# The annotations below are put in comments for compatibility with Python 3.7
+# as it doesn't allow names declared as `global` within functions to be annotated.
+
 # Set by `update_menu()`
-menu_list: Optional[list] = None
-at_top_level: Optional[bool] = None
+menu_list = None  #: Optional[list]
+at_top_level = None  #: Optional[bool]
 
 # Intially set from `.__main__.main()`
 # Will be updated from `.logging.init_log()` if multiprocessing is enabled


### PR DESCRIPTION
The bug was introduced in f4a6247

Released in [v0.3.1](https://github.com/AnonymouX47/term-image/releases/tag/v0.3.1).