### PR TITLE
Automatic render-style selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] A common interface to be shared across all image classes ([#34]).
 - [lib] `BaseImage`, the baseclass of all image classes ([#34]).
 - [lib] `is_supported()` class method for render style support detection ([#34]).
+- [lib] Convenience functions for automatic render style selection ([#37]).
+  - `AutoImage()`, `from_file()` and `from_url()` in `term_image.image`.
+- [cli,tui] `--style` command-line option for render style selection ([#37]).
+- [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
 
 ### Changed
 - [lib] `TermImage` is now a subclass of `BaseImage` ([#34]).
 - [lib] Instantiation via the class constructor now initializes the seek position of animated images to the current seek position of the given PIL image ([#34]).
 
 [#34]: https://github.com/AnonymouX47/term-image/pull/34
+[#37]: https://github.com/AnonymouX47/term-image/pull/37
 
 
 ## [0.3.1] - 2022-05-04

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint:
 
 # Executing using `python -m` adds CWD to `sys.path`.
 
-test: test-base test-iterator
+test: test-base test-iterator test-others
 
 test-text: test-term
 
@@ -39,6 +39,9 @@ test-base:
 
 test-iterator:
 	python -m pytest -v tests/test_image_iterator.py
+
+test-others:
+	python -m pytest -v tests/test_others.py
 
 test-term:
 	python -m pytest -v tests/test_term.py

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -2,13 +2,42 @@ Core Library Definitions
 ========================
 
 .. automodule:: term_image.image
-   :members:
-   :imported-members:
-   :show-inheritance:
 
    The ``term_image.image`` subpackage defines the following:
 
+
+   Convenience Functions
+   ---------------------
+
+   These functions automatically detect the best supported render style for the
+   current terminal.
+
+   Since all classes define a common interface, any operation supported by one image
+   class can be performed on any other image class, except stated otherwise.
+
+   .. autofunction:: AutoImage
+
+   .. autofunction:: from_file
+
+   .. autofunction:: from_url
+
+
+   Image Classes
+   -------------
+
    .. note:: It's allowed to set properties for :term:`animated` images on non-animated ones, the values are simply ignored.
+
+   .. autoclass:: BaseImage
+      :members:
+      :show-inheritance:
+
+   .. autoclass:: TermImage
+      :members:
+      :show-inheritance:
+
+   .. autoclass:: ImageIterator
+      :members:
+      :show-inheritance:
 
 |
 

--- a/term_image/image/__init__.py
+++ b/term_image/image/__init__.py
@@ -4,7 +4,73 @@
 
 from __future__ import annotations
 
-__all__ = ("BaseImage", "TermImage", "ImageIterator")
+__all__ = (
+    "AutoImage",
+    "from_file",
+    "from_url",
+    "BaseImage",
+    "TermImage",
+    "ImageIterator",
+)
+
+from typing import Optional, Tuple, Union
+
+import PIL
 
 from .common import BaseImage, ImageIterator  # noqa:F401
 from .term import TermImage  # noqa:F401
+
+
+def AutoImage(
+    image: PIL.Image.Image,
+    *,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+    scale: Tuple[float, float] = (1.0, 1.0),
+) -> BaseImage:
+    """Convenience function for creating an image instance from a PIL image instance.
+
+    Returns:
+        An instance of a subclass of :py:class:`BaseImage`.
+
+    Same arguments and raised exceptions as the :py:class:`BaseImage` class constructor.
+    """
+    return _best_style()(image, width=width, height=height, scale=scale)
+
+
+def from_file(
+    filepath: str,
+    **kwargs: Union[None, int, Tuple[float, float]],
+) -> BaseImage:
+    """Convenience function for creating an image instance from an image file.
+
+    Returns:
+        An instance of a subclass of :py:class:`BaseImage`.
+
+    Same arguments and raised exceptions as :py:meth:`BaseImage.from_file`.
+    """
+    return _best_style().from_file(filepath, **kwargs)
+
+
+def from_url(
+    url: str,
+    **kwargs: Union[None, int, Tuple[float, float]],
+) -> BaseImage:
+    """Convenience function for creating an image instance from an image URL.
+
+    Returns:
+        An instance of a subclass of :py:class:`BaseImage`.
+
+    Same arguments and raised exceptions as :py:meth:`BaseImage.from_url`.
+    """
+    return _best_style().from_url(url, **kwargs)
+
+
+def _best_style():
+    for cls in _styles:
+        if cls.is_supported():
+            break
+    return cls
+
+
+_styles = (TermImage,)

--- a/term_image/tui/__init__.py
+++ b/term_image/tui/__init__.py
@@ -22,6 +22,7 @@ def init(
     args: argparse.Namespace,
     images: Iterable[Tuple[str, Union[Image, Iterator]]],
     contents: dict,
+    ImageClass: type,
 ) -> None:
     """Initializes the TUI"""
     global is_launched
@@ -44,6 +45,7 @@ def init(
     main.REPEAT = args.repeat
     main.RECURSIVE = args.recursive
     main.SHOW_HIDDEN = args.all
+    main.ImageClass = ImageClass
     main.loop = Loop(main_widget, palette, unhandled_input=process_input)
     main.update_pipe = main.loop.watch_pipe(lambda _: None)
 

--- a/term_image/tui/main.py
+++ b/term_image/tui/main.py
@@ -17,7 +17,7 @@ import urwid
 
 from .. import logging, notify, tui
 from ..config import context_keys, expand_key
-from ..image import ImageIterator, TermImage
+from ..image import ImageIterator
 from .keys import (
     disable_actions,
     display_context_keys,
@@ -446,7 +446,7 @@ def scan_dir(
         yield result, (
             entry.name,
             (
-                Image(TermImage.from_file(entry.path))
+                Image(ImageClass.from_file(entry.path))
                 if result == IMAGE
                 else ...
                 if result == DIR
@@ -742,6 +742,7 @@ at_top_level = None  #: Optional[bool]
 interrupted: Union[None, Event, mp_Event] = None
 
 # Set from `.tui.init()`
+ImageClass: type
 displayer: Optional[Generator[None, int, bool]] = None
 loop: Optional[tui.Loop] = None
 update_pipe: Optional[int] = None

--- a/term_image/tui/widgets.py
+++ b/term_image/tui/widgets.py
@@ -13,7 +13,7 @@ import urwid
 
 from .. import logging
 from ..config import _nav, cell_width, expand_key, nav
-from ..image import TermImage
+from ..image import BaseImage
 from ..image.common import _ALPHA_THRESHOLD
 from . import keys, main as tui_main
 from .render import grid_render_queue, image_render_queue
@@ -170,7 +170,7 @@ class Image(urwid.Widget):
 
     _alpha = f"{_ALPHA_THRESHOLD}"[1:]  # Updated from `.tui.init()`
 
-    def __init__(self, image: TermImage):
+    def __init__(self, image: BaseImage):
         self._image = image
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -1,0 +1,35 @@
+import pytest
+
+from term_image.image import AutoImage, BaseImage, from_file
+
+from .test_base import python_image, python_img
+
+
+class TestConvinience:
+    def test_auto_image(self):
+        with pytest.raises(TypeError, match=r"'PIL\.Image\.Image' instance"):
+            AutoImage(python_image)
+
+        # Ensure size arguments get through
+        with pytest.raises(ValueError, match=r"both width and height"):
+            AutoImage(python_img, width=1, height=1)
+
+        # Ensure scale argument gets through
+        with pytest.raises(TypeError, match=r"'scale'"):
+            AutoImage(python_img, scale=0.5)
+
+        assert isinstance(AutoImage(python_img), BaseImage)
+
+    def test_from_file(self):
+        with pytest.raises(TypeError, match=r"a string"):
+            from_file(python_img)
+
+        # Ensure size arguments get through
+        with pytest.raises(ValueError, match=r"both width and height"):
+            from_file(python_image, width=1, height=1)
+
+        # Ensure scale argument gets through
+        with pytest.raises(TypeError, match=r"'scale'"):
+            from_file(python_image, scale=1.0)
+
+        assert isinstance(from_file(python_image), BaseImage)

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -4,7 +4,7 @@ import pytest
 from PIL import Image, UnidentifiedImageError
 
 from term_image.exceptions import URLNotFoundError
-from term_image.image import TermImage
+from term_image.image import BaseImage, TermImage, from_url
 
 python_image = "tests/images/python.png"
 python_url = (
@@ -50,3 +50,19 @@ def test_close():
     assert os.path.exists(image._source)
     image.close()
     assert not os.path.exists(image._source)
+
+
+class TestConvinience:
+    def test_from_url(self):
+        with pytest.raises(TypeError, match=r"a string"):
+            from_url(python_img)
+
+        # Ensure size arguments get through
+        with pytest.raises(ValueError, match=r"both width and height"):
+            from_url(python_url, width=1, height=1)
+
+        # Ensure scale argument gets through
+        with pytest.raises(TypeError, match=r"'scale'"):
+            from_url(python_url, scale=1.0)
+
+        assert isinstance(from_url(python_url), BaseImage)


### PR DESCRIPTION
In line with #23

- Adds convenience functions for creating image instances, which select the best fitting render style based on the detected terminal support.
  - `AutoImage()`, `from_file()` and `from_url()` in `term_image.image`.
- Adds CLI option `--style` to specify the render style to use.