### PR TITLE
Image source-related features and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `is_supported()` class method for render style support detection ([#34]).
 - [lib] Convenience functions for automatic render style selection ([#37]).
   - `AutoImage()`, `from_file()` and `from_url()` in `term_image.image`.
+- [lib] `BaseImage.source_type` property ([#38]).
 - [cli,tui] `--style` command-line option for render style selection ([#37]).
 - [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
 
@@ -18,10 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `TermImage` is now a subclass of `BaseImage` ([#34]).
 - [lib] Instantiation via the class constructor now initializes the seek position of animated images to the current seek position of the given PIL image ([#34]).
 - [lib] On UNIX, the library now attempts to determine the proper terminal device to use when standard streams are redirected to files or pipes ([#36]).
+- [lib] `BaseImage.source` now raises `TermImageException` when invoked after the instance has been finalized ([#38]).
+- [lib] Improved `repr()` of image instances ([#38]).
 
 [#34]: https://github.com/AnonymouX47/term-image/pull/34
 [#36]: https://github.com/AnonymouX47/term-image/pull/36
 [#37]: https://github.com/AnonymouX47/term-image/pull/37
+[#38]: https://github.com/AnonymouX47/term-image/pull/38
 
 
 ## [0.3.1] - 2022-05-04

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -27,6 +27,10 @@ Core Library Definitions
 
    .. note:: It's allowed to set properties for :term:`animated` images on non-animated ones, the values are simply ignored.
 
+   .. autoclass:: ImageSource
+      :members:
+      :show-inheritance:
+
    .. autoclass:: BaseImage
       :members:
       :show-inheritance:

--- a/term_image/image/__init__.py
+++ b/term_image/image/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = ("BaseImage", "TermImage", "ImageIterator")
+__all__ = ("ImageSource", "BaseImage", "TermImage", "ImageIterator")
 
-from .common import BaseImage, ImageIterator  # noqa:F401
+from .common import BaseImage, ImageIterator, ImageSource  # noqa:F401
 from .term import TermImage  # noqa:F401

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -388,7 +388,12 @@ class BaseImage(ABC):
         self._v_allow = 2  # A 2-line allowance for the shell prompt, etc
 
     source = property(
-        lambda self: (self._url if hasattr(self, "_url") else self._source),
+        lambda self: getattr(self, self._source_type.value),
+        doc="""
+        The :term:`source` from which the instance was initialized.
+
+        Returns:
+            A PIL image, file path or URL.
         """,
     )
 

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -72,7 +72,7 @@ class ImageSource(Enum):
         value of enum members, because some would normally compare equal.
         """
 
-        def __init__(self, *args):
+        def __init__(self, *_):
             self._str = super().__str__()
 
         def __eq__(*_):
@@ -85,8 +85,13 @@ class ImageSource(Enum):
         __ne__ = __eq__
         __ascii__ = __str__ = __repr__
 
+    #: The instance was derived from a path to a local image file.
     FILE_PATH = _SourceAttr("_source")
+
+    #: The instance was derived from a PIL image instance.
     PIL_IMAGE = _SourceAttr("_source")
+
+    #: The instance was derived from an image URL.
     URL = _SourceAttr("_url")
 
 

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -388,7 +388,7 @@ class BaseImage(ABC):
         self._v_allow = 2  # A 2-line allowance for the shell prompt, etc
 
     source = property(
-        lambda self: getattr(self, self._source_type.value),
+        _close_validated(lambda self: getattr(self, self._source_type.value)),
         doc="""
         The :term:`source` from which the instance was initialized.
 
@@ -445,15 +445,15 @@ class BaseImage(ABC):
         """
         try:
             if not self._closed:
-                if (
-                    hasattr(self, "_url")
-                    # The file might not exist for whatever reason.
-                    and os.path.exists(self._source)
-                ):
-                    os.remove(self._source)
+                if self._source_type is ImageSource.URL:
+                    try:
+                        os.remove(self._source)
+                    except FileNotFoundError:
+                        pass
+                    del self._url
+                del self._source
         except AttributeError:
-            # Instance creation or initialization was unsuccessful
-            pass
+            pass  # Instance creation or initialization was unsuccessful
         finally:
             self._closed = True
 

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -200,14 +200,11 @@ class BaseImage(ABC):
         return ImageIterator(self, 1, "1.1", False)
 
     def __repr__(self) -> str:
-        return (
-            "<{}(source={!r}, original_size={}, size={}, scale={}, is_animated={})>"
-        ).format(
+        return "<{}: source_type={} size={} scale={} is_animated={}>".format(
             type(self).__name__,
-            (self._url if hasattr(self, "_url") else self._source),
-            self._original_size,
-            self._size,
-            self.scale,  # Stored as a list but should be shown as a tuple
+            self._source_type.name,
+            self._size and "x".join(map(str, self._size)),
+            "x".join(format(x, ".2") for x in self._scale),
             self._is_animated,
         )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,8 +9,7 @@ import pytest
 from PIL import Image, UnidentifiedImageError
 
 from term_image import set_font_ratio
-from term_image.exceptions import InvalidSize
-from term_image.image import ImageIterator, TermImage
+from term_image.exceptions import InvalidSize, TermImageException
 from term_image.image import ImageIterator, ImageSource, TermImage
 
 from .common import _size, columns, lines, python_img, setup_common
@@ -323,6 +322,22 @@ class TestProperties:
             image.source == os.path.abspath(python_sym) != os.path.realpath(python_sym)
         )
         assert image.source_type is ImageSource.FILE_PATH
+
+
+def test_close():
+    image = TermImage(python_img)
+    image.close()
+    assert image.closed
+    with pytest.raises(AttributeError):
+        image._source
+    with pytest.raises(TermImageException):
+        image.source
+    with pytest.raises(TermImageException):
+        str(image)
+    with pytest.raises(TermImageException):
+        format(image)
+    with pytest.raises(TermImageException):
+        image.draw()
 
 
 def test_context_management():

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,6 +11,7 @@ from PIL import Image, UnidentifiedImageError
 from term_image import set_font_ratio
 from term_image.exceptions import InvalidSize
 from term_image.image import ImageIterator, TermImage
+from term_image.image import ImageIterator, ImageSource, TermImage
 
 from .common import _size, columns, lines, python_img, setup_common
 
@@ -49,6 +50,7 @@ class TestConstructor:
         assert isinstance(image._scale, list)
         assert image._scale == [1.0, 1.0]
         assert image._source is python_img
+        assert image._source_type is ImageSource.PIL_IMAGE
         assert isinstance(image._original_size, tuple)
         assert image._original_size == python_img.size
 
@@ -99,6 +101,7 @@ class TestFromFile:
         image = TermImage.from_file(python_image)
         assert isinstance(image, TermImage)
         assert image._source == os.path.abspath(python_image)
+        assert image._source_type is ImageSource.FILE_PATH
 
     @pytest.mark.skipif(
         not os.path.islink(python_sym),
@@ -108,6 +111,8 @@ class TestFromFile:
     def test_symlink(self):
         image = TermImage.from_file(python_sym)
         assert isinstance(image, TermImage)
+        assert image._source == os.path.abspath(python_sym)
+        assert image._source_type is ImageSource.FILE_PATH
 
 
 class TestProperties:
@@ -297,9 +302,11 @@ class TestProperties:
     def test_source(self):
         image = TermImage(python_img)
         assert image.source is python_img
+        assert image.source_type is ImageSource.PIL_IMAGE
 
         image = TermImage.from_file(python_image)
         assert image.source == os.path.abspath(python_image)
+        assert image.source_type is ImageSource.FILE_PATH
 
         with pytest.raises(AttributeError):
             image.source = None
@@ -315,6 +322,7 @@ class TestProperties:
         assert (
             image.source == os.path.abspath(python_sym) != os.path.realpath(python_sym)
         )
+        assert image.source_type is ImageSource.FILE_PATH
 
 
 def test_context_management():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -49,6 +49,9 @@ def test_source():
 
 def test_close():
     image = TermImage.from_url(python_url)
-    assert os.path.exists(image._source)
+    source = image._source
+
     image.close()
-    assert not os.path.exists(image._source)
+    assert not os.path.exists(source)
+    with pytest.raises(AttributeError):
+        image._url

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -4,7 +4,7 @@ import pytest
 from PIL import Image, UnidentifiedImageError
 
 from term_image.exceptions import URLNotFoundError
-from term_image.image import TermImage
+from term_image.image import ImageSource, TermImage
 
 python_image = "tests/images/python.png"
 python_url = (
@@ -30,6 +30,7 @@ def test_from_url():
     assert isinstance(image, TermImage)
     assert image._url == python_url
     assert os.path.exists(image._source)
+    assert image._source_type is ImageSource.URL
 
     # Ensure size arguments get through
     with pytest.raises(ValueError, match=r".* both width and height"):
@@ -42,7 +43,8 @@ def test_from_url():
 
 def test_source():
     image = TermImage.from_url(python_url)
-    assert image._url == python_url
+    assert image.source == image._url == python_url
+    assert image.source_type is ImageSource.URL
 
 
 def test_close():


### PR DESCRIPTION
- Adds `BaseImage.source_type` property.
- Updates `BaseImage`'s `repr()`.
- Improves instance finalization.
- `BaseImage.source` now raises `TermImageException` when invoked after the instance has been finalized.