### PR TITLE
Improvements to render style support and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `KittyImage` class ([#39]).
 - [lib] Support for multiple render methods per render style via `BaseImage.set_render_method()` ([#39]).
 - [lib] Non-linear image iteration via `ImageIterator.seek()` ([#42]).
+- [lib] Image category subclasses (of `BaseImage`), `TextImage` and `GraphicsImage` ([#44]).
 - [cli] `kitty` render style choice for the `--style` CL option ([#39]).
+- [cli] `--force-style` to bypass render style support checks ([#44]).
 - [tui] Concurrent/Parallel frame rendering for TUI animations ([#42]).
 - [cli,tui] `--style` command-line option for render style selection ([#37]).
 - [lib,cli,tui] Support for the Kitty terminal graphics protocol ([#39]).
@@ -34,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] On UNIX, the library now attempts to determine the proper terminal device to use when standard streams are redirected to files or pipes ([#36]).
 - [lib] `BaseImage.source` now raises `TermImageException` when invoked after the instance has been finalized ([#38]).
 - [lib] Improved `repr()` of image instances ([#38]).
+- [lib] Direct baseclass of `TermImage` to `TextImage` ([#44]).
+- [cli] `-S` from `--scroll` to `--style` ([#44]).
 
 [#34]: https://github.com/AnonymouX47/term-image/pull/34
 [#36]: https://github.com/AnonymouX47/term-image/pull/36
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/AnonymouX47/term-image/pull/41
 [#42]: https://github.com/AnonymouX47/term-image/pull/42
 [#43]: https://github.com/AnonymouX47/term-image/pull/43
+[#44]: https://github.com/AnonymouX47/term-image/pull/44
 
 
 ## [0.3.1] - 2022-05-04

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -35,6 +35,14 @@ Core Library Definitions
       :members:
       :show-inheritance:
 
+   .. autoclass:: GraphicsImage
+      :members:
+      :show-inheritance:
+
+   .. autoclass:: TextImage
+      :members:
+      :show-inheritance:
+
    .. autoclass:: KittyImage
       :members:
       :show-inheritance:

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -20,6 +20,40 @@ Top-Level Functions
 
 .. _format-spec:
 
+
+.. _render-styles:
+
+Render Styles
+-------------
+
+A render style is a specific implementation of representing or drawing images in a terminal emulator and each is implemented as a class.
+
+All render styles are designed to share a common interface (with some having extensions), making the usage of one class directly compatibile with another.
+
+| Hence, the covenience functions :py:class:`AutoImage <term_image.image.AutoImage>`, :py:class:`from_file() <term_image.image.from_file>` and :py:class:`from_url() <term_image.image.from_url>` provide a means of render-style-independent usage of the library.
+| These functions automatically detect the best render style supported by the :term:`active terminal`.
+
+There a two categories of render styles:
+
+Text-based Render Styles
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Represent images using ASCII or Unicode symbols, and in some cases, in conjunction with ANSI colour escape codes.
+
+Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
+
+- :py:class:`TermImage <term_image.image.TermImage>`.
+
+Graphics-based Render Styles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Represent images with actual pixels, using terminal graphics protocols.
+
+Classes for render styles in this category are subclasses of :py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
+
+- :py:class:`KittyImage <term_image.image.KittyImage>`.
+
+
 Image Format Specification
 --------------------------
 

--- a/docs/source/viewer/index.rst
+++ b/docs/source/viewer/index.rst
@@ -54,6 +54,20 @@ Note that some options are only applicable to a specific mode. If used with the 
 | All footnotes are at the bottom of the help text.
 
 
+Render Styles
+-------------
+
+See :ref:`render-styles`.
+
+| By default, ``term-image`` automatically detects the best style supported by the :term:`active terminal`.
+
+| A particular render style can be specified using the ``-S | --style`` command-line option.
+| If the specified render style is graphics-based and not supported, an error notification is emitted and the process exits with code ``1``.
+| If the specified render style is text-based and not [fully] supported, a warning notification is emitted but execution still proceeds with the style.
+
+The ``--force-style`` command-line option can be used to bypass style support checks and force the usage of any style whether it's supported or not.
+
+
 Notifications
 -------------
 

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -577,7 +577,8 @@ Render Styles:
         with a density of two pixels per character cell.
 
     Using a terminal-graphics-based style not supported by the active terminal is not
-    allowed.
+    allowed by default.
+    To force a style that is normally unsupported, add the '--force-style' flag.
 
 FOOTNOTES:
   1. The displayed image uses HEIGHT/2 lines, while the number of columns is dependent
@@ -645,6 +646,14 @@ FOOTNOTES:
         help=(
             "Specify the image render style (default: auto). "
             'See "Render Styles" below'
+        ),
+    )
+    general.add_argument(
+        "--force-style",
+        action="store_true",
+        help=(
+            "Use the specified render style even if it's reported as unsupported by "
+            "the active terminal"
         ),
     )
 
@@ -1083,6 +1092,11 @@ FOOTNOTES:
     ImageClass = {"auto": _best_style(), "kitty": KittyImage, "term": TermImage}[
         args.style
     ]
+
+    style = ImageClass.__name__[:-5].lower()
+    if args.force_style:
+        ImageClass._supported = True
+    log(f"Using {style!r} render style", logger, direct=False)
 
     log("Processing sources", logger, loading=True)
 

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -20,14 +20,14 @@ import requests
 
 from . import __version__, config, logging, notify, set_font_ratio, tui
 from .config import config_options, store_config
-from .exceptions import URLNotFoundError
+from .exceptions import TermImageException, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
 from .image import KittyImage, TermImage, _best_style
 from .image.common import _ALPHA_THRESHOLD
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
 from .tui.widgets import Image
-from .utils import OS_IS_UNIX
+from .utils import OS_IS_UNIX, write_output
 
 
 def check_dir(
@@ -584,7 +584,7 @@ FOOTNOTES:
   1. The displayed image uses HEIGHT/2 lines, while the number of columns is dependent
      on the WIDTH and the FONT RATIO.
      The auto sizing is calculated such that the image always fits into the available
-     terminal size (i.e terminal size minus allowances) except when `-S` is
+     terminal size (i.e terminal size minus allowances) except when `--scroll` is
      specified, which allows the image height to go beyond the terminal height.
   2. The size is multiplied by the scale on each axis respectively before the image
      is rendered. A scale value must be such that 0.0 < value <= 1.0.
@@ -640,6 +640,7 @@ FOOTNOTES:
         ),
     )
     general.add_argument(
+        "-S",
         "--style",
         choices=("auto", "kitty", "term"),
         default="auto",
@@ -804,7 +805,6 @@ FOOTNOTES:
         ),
     )
     cli_options.add_argument(
-        "-S",
         "--scroll",
         action="store_true",
         help=(
@@ -1089,14 +1089,37 @@ FOOTNOTES:
 
     set_font_ratio(args.font_ratio)
 
-    ImageClass = {"auto": _best_style(), "kitty": KittyImage, "term": TermImage}[
-        args.style
-    ]
+    ImageClass = {"auto": None, "kitty": KittyImage, "term": TermImage}[args.style]
+    if not ImageClass:
+        ImageClass = _best_style()
 
     style = ImageClass.__name__[:-5].lower()
     if args.force_style:
         ImageClass._supported = True
+    else:
+        try:
+            ImageClass(None)
+        except TermImageException:  # Instantiation isn't permitted
+            log(
+                f"The {style!r} render style is not supported in the current "
+                "terminal! To use it anyways, add '--force-style'.",
+                logger,
+                level=_logging.CRITICAL,
+            )
+            return FAILURE
+        except TypeError:  # Instantiation is permitted
+            if not ImageClass.is_supported():
+                log(
+                    f"The {style!r} render style might not be fully supported in "
+                    "the current terminal... using it anyways.",
+                    logger,
+                    level=_logging.WARNING,
+                )
     log(f"Using {style!r} render style", logger, direct=False)
+
+    # Some APCs used for render style support detection get emitted on some
+    # non-supporting terminal emulators
+    write_output(b"\033[1K\r")
 
     log("Processing sources", logger, loading=True)
 

--- a/term_image/image/__init__.py
+++ b/term_image/image/__init__.py
@@ -10,6 +10,8 @@ __all__ = (
     "from_url",
     "ImageSource",
     "BaseImage",
+    "GraphicsImage",
+    "TextImage",
     "KittyImage",
     "TermImage",
     "ImageIterator",
@@ -19,7 +21,13 @@ from typing import Optional, Tuple, Union
 
 import PIL
 
-from .common import BaseImage, ImageIterator, ImageSource  # noqa:F401
+from .common import (  # noqa:F401
+    BaseImage,
+    GraphicsImage,
+    ImageIterator,
+    ImageSource,
+    TextImage,
+)
 from .kitty import KittyImage  # noqa:F401
 from .term import TermImage  # noqa:F401
 

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -1521,6 +1521,10 @@ class BaseImage(ABC):
 class GraphicsImage(BaseImage):
     """Base of all render styles using terminal graphics protocols.
 
+    Raises:
+        term_image.exceptions.TermImageException: The :term:`active terminal` doesn't
+          support the render style.
+
     See :py:class:`BaseImage` for the description of the constructor.
 
     ATTENTION:
@@ -1531,11 +1535,25 @@ class GraphicsImage(BaseImage):
     # Size unit conversion already involves cell size calculation
     _pixel_ratio: float = 1.0
 
+    def __init__(self, image: PIL.Image.Image, **kwargs) -> None:
+        if not self.is_supported():
+            raise TermImageException(
+                "This image render style is not supported in the active terminal"
+            )
+        super().__init__(image, **kwargs)
+
 
 class TextImage(BaseImage):
     """Base of all render styles using ASCII/Unicode symbols [with ANSI color codes].
 
     See :py:class:`BaseImage` for the description of the constructor.
+
+    IMPORTANT:
+        Instantiation of subclasses is always allowed, even if the current terminal
+        does not [fully] support the render style.
+
+        To check if the render style is fully supported in the current terminal, use
+        :py:meth:`is_supported() <BaseImage.is_supported>`.
 
     ATTENTION:
         This class cannot be directly instantiated. Image instances should be created

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -17,21 +17,21 @@ import PIL
 
 from ..exceptions import TermImageException
 from ..utils import get_cell_size, lock_input, query_terminal
-from .common import BaseImage
+from .common import GraphicsImage
 
 # Constants for ``KittyImage`` render method
 LINES = "lines"
 WHOLE = "whole"
 
 
-class KittyImage(BaseImage):
-    """An image based on the Kitty terminal graphics protocol.
+class KittyImage(GraphicsImage):
+    """A render style using the Kitty terminal graphics protocol.
 
     Raises:
         term_image.exceptions.TermImageException: The :term:`active terminal` doesn't
           support the protocol.
 
-    See :py:class:`BaseImage` for the complete description of the constructor.
+    See :py:class:`GraphicsImage` for the complete description of the constructor.
 
     **Render Methods:**
 
@@ -69,9 +69,6 @@ class KittyImage(BaseImage):
           * `Kitty <https://sw.kovidgoyal.net/kitty/>`_ >= 0.20.0.
           * `Konsole <https://konsole.kde.org>`_ >= 22.04.0.
     """
-
-    # Size unit conversion already involves cell size calculation
-    _pixel_ratio: float = 1.0
 
     _render_methods: Set[str] = {LINES, WHOLE}
     _default_render_method: str = LINES

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -15,7 +15,6 @@ from zlib import compress, decompress
 
 import PIL
 
-from ..exceptions import TermImageException
 from ..utils import get_cell_size, lock_input, query_terminal
 from .common import GraphicsImage
 
@@ -26,10 +25,6 @@ WHOLE = "whole"
 
 class KittyImage(GraphicsImage):
     """A render style using the Kitty terminal graphics protocol.
-
-    Raises:
-        term_image.exceptions.TermImageException: The :term:`active terminal` doesn't
-          support the protocol.
 
     See :py:class:`GraphicsImage` for the complete description of the constructor.
 
@@ -73,13 +68,6 @@ class KittyImage(GraphicsImage):
     _render_methods: Set[str] = {LINES, WHOLE}
     _default_render_method: str = LINES
     _render_method: str = LINES
-
-    def __init__(self, image: PIL.Image.Image, **kwargs) -> None:
-        if not self.is_supported():
-            raise TermImageException(
-                "This image render style is not supported in the current terminal"
-            )
-        super().__init__(image, **kwargs)
 
     @classmethod
     @lock_input

--- a/term_image/image/term.py
+++ b/term_image/image/term.py
@@ -11,16 +11,16 @@ from typing import Optional, Tuple, Union
 import PIL
 
 from ..utils import _BG_FMT, _FG_FMT, _RESET
-from .common import BaseImage
+from .common import TextImage
 
 _LOWER_PIXEL = "\u2584"  # lower-half block element
 _UPPER_PIXEL = "\u2580"  # upper-half block element
 
 
-class TermImage(BaseImage):
-    """Text-based image using unicode blocks and ANSI 24-bit colour escape codes.
+class TermImage(TextImage):
+    """A render style using unicode half blocks and ANSI 24-bit colour escape codes.
 
-    See :py:class:`BaseImage` for the description of the constructor.
+    See :py:class:`TextImage` for the description of the constructor.
     """
 
     @classmethod

--- a/term_image/logging_multi.py
+++ b/term_image/logging_multi.py
@@ -7,7 +7,7 @@ import os
 from multiprocessing import JoinableQueue, Process
 from traceback import format_exception
 
-from . import cli, logging, notify
+from . import cli, logging, notify, tui
 
 
 def process_multi_logs() -> None:
@@ -56,6 +56,8 @@ class Process(Process):
             "redirect_notifs": redirect_notifs,
         }
         self._main_process_interruped = cli.interrupted
+        self._ImageClass = tui.main.ImageClass
+        self._force_style = cli.args.force_style
         child_processes.append(self)
 
     def run(self):
@@ -63,6 +65,9 @@ class Process(Process):
         _logger.debug("Starting")
 
         try:
+            if self._force_style and self._ImageClass:
+                # The unpickled class object is in the originally defined state
+                self._ImageClass._supported = True
             super().run()
         except KeyboardInterrupt:
             # Log only if the main process was not interruped

--- a/term_image/tui/main.py
+++ b/term_image/tui/main.py
@@ -702,7 +702,7 @@ menu_list = None  #: Optional[list]
 at_top_level = None  #: Optional[bool]
 
 # Set from `.tui.init()`
-ImageClass: type
+ImageClass: Optional[type] = None
 displayer: Optional[Generator[None, int, bool]] = None
 loop: Optional[tui.Loop] = None
 update_pipe: Optional[int] = None

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,8 @@ import pytest
 from PIL import Image
 
 from term_image import set_font_ratio
-from term_image.image.common import _ALPHA_THRESHOLD
+from term_image.exceptions import TermImageException
+from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, TextImage
 from term_image.utils import get_terminal_size
 
 columns, lines = get_terminal_size()
@@ -89,6 +90,29 @@ def width_height(image, *, w=None, h=None):
     )
 
 
+def test_instantiation_Text():
+    original = ImageClass._supported
+    try:
+        ImageClass._supported = True
+        assert isinstance(ImageClass(python_img), TextImage)
+        ImageClass._supported = False
+        assert isinstance(ImageClass(python_img), TextImage)
+    finally:
+        ImageClass._supported = original
+
+
+def test_instantiation_Graphics():
+    original = ImageClass._supported
+    try:
+        ImageClass._supported = True
+        assert isinstance(ImageClass(python_img), GraphicsImage)
+        ImageClass._supported = False
+        with pytest.raises(TermImageException):
+            ImageClass(python_img)
+    finally:
+        ImageClass._supported = original
+
+
 def test_str_All():
     image = ImageClass(python_img, width=_size)
     assert str(image) == image._render_image(python_img, _ALPHA_THRESHOLD)
@@ -97,6 +121,7 @@ def test_str_All():
 def test_format_All():
     image = ImageClass(python_img)
     image.set_size()
+    image.scale = 0.5  # Leave some space for formatting
     assert format(image) == image._format_render(str(image))
 
 
@@ -265,7 +290,7 @@ class TestFontRatio_Text:
             set_font_ratio(0.5)
 
 
-class TestFontRatio_Graphic:
+class TestFontRatio_Graphics:
     def test_setup(self):
         type(self).image = ImageClass(python_img)  # Square
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -11,7 +11,7 @@ from .common import *  # noqa:F401
 from .common import _size, setup_common
 
 for name in tuple(globals()):
-    if name.endswith("_Graphic"):
+    if name.endswith("_Graphics"):
         del globals()[name]
 
 


### PR DESCRIPTION
- Introduces render style categories.
  - Adds `TextImage` and `GraphicsImage` (subclasses of `BaseImage`) in `.image`.
  - Moves `_pixel_ratio` definitions into category baseclasses and turns `BaseImage._pixel_ratio` into an abstract property.
  - Changes the baseclass of `TermImage` to `TextImage`.
  - Changes the baseclass of `KittyImage` to `GraphicsImage`.
- Improves render style selection and support detection.
- Adds `--force-style`.
- Changes `-S` from `--scroll` to `--style`.
- Documents render style support.