### PR TITLE
Auto font ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `KittyImage` class ([#39]).
 - [lib] Support for multiple render methods per render style via `BaseImage.set_render_method()` ([#39]).
 - [lib] Non-linear image iteration via `ImageIterator.seek()` ([#42]).
+- [lib] Automatic font ratio computation ([#45]).
+- [lib] `term_image.FontRatio` enumeration class ([#45]).
+- [cli] `--style` command-line option for render style selection ([#37]).
 - [cli] `kitty` render style choice for the `--style` CL option ([#39]).
+- [cli] `--auto-font-ratio` for automatic font ratio determination ([#45]).
 - [tui] Concurrent/Parallel frame rendering for TUI animations ([#42]).
-- [cli,tui] `--style` command-line option for render style selection ([#37]).
 - [lib,cli,tui] Support for the Kitty terminal graphics protocol ([#39]).
 - [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
 
@@ -34,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] On UNIX, the library now attempts to determine the proper terminal device to use when standard streams are redirected to files or pipes ([#36]).
 - [lib] `BaseImage.source` now raises `TermImageException` when invoked after the instance has been finalized ([#38]).
 - [lib] Improved `repr()` of image instances ([#38]).
+- [cli,tui] Changed default value of `font ratio` config option to `null` ([#45]).
 
 [#34]: https://github.com/AnonymouX47/term-image/pull/34
 [#36]: https://github.com/AnonymouX47/term-image/pull/36
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/AnonymouX47/term-image/pull/41
 [#42]: https://github.com/AnonymouX47/term-image/pull/42
 [#43]: https://github.com/AnonymouX47/term-image/pull/43
+[#45]: https://github.com/AnonymouX47/term-image/pull/45
 
 
 ## [0.3.1] - 2022-05-04

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -28,6 +28,39 @@ Top-Level Definitions
 |
 
 
+.. _render-styles:
+
+Render Styles
+-------------
+
+A render style is a specific implementation of representing or drawing images in a terminal emulator and each is implemented as a class.
+
+All render styles are designed to share a common interface (with some having extensions), making the usage of one class directly compatibile with another.
+
+| Hence, the covenience functions :py:class:`AutoImage <term_image.image.AutoImage>`, :py:class:`from_file() <term_image.image.from_file>` and :py:class:`from_url() <term_image.image.from_url>` provide a means of render-style-independent usage of the library.
+| These functions automatically detect the best render style supported by the :term:`active terminal`.
+
+There a two categories of render styles:
+
+Text-based Render Styles
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Represent images using ASCII or Unicode symbols, and in some cases, in conjunction with ANSI colour escape codes.
+
+Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
+
+- :py:class:`TermImage <term_image.image.TermImage>`.
+
+Graphics-based Render Styles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Represent images with actual pixels, using terminal graphics protocols.
+
+Classes for render styles in this category are subclasses of :py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
+
+- :py:class:`KittyImage <term_image.image.KittyImage>`.
+
+
 .. _auto-font-ratio:
 
 Auto Font Ratio
@@ -64,40 +97,6 @@ About #2 and #3
 
 
 .. _format-spec:
-
-
-.. _render-styles:
-
-Render Styles
--------------
-
-A render style is a specific implementation of representing or drawing images in a terminal emulator and each is implemented as a class.
-
-All render styles are designed to share a common interface (with some having extensions), making the usage of one class directly compatibile with another.
-
-| Hence, the covenience functions :py:class:`AutoImage <term_image.image.AutoImage>`, :py:class:`from_file() <term_image.image.from_file>` and :py:class:`from_url() <term_image.image.from_url>` provide a means of render-style-independent usage of the library.
-| These functions automatically detect the best render style supported by the :term:`active terminal`.
-
-There a two categories of render styles:
-
-Text-based Render Styles
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Represent images using ASCII or Unicode symbols, and in some cases, in conjunction with ANSI colour escape codes.
-
-Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
-
-- :py:class:`TermImage <term_image.image.TermImage>`.
-
-Graphics-based Render Styles
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Represent images with actual pixels, using terminal graphics protocols.
-
-Classes for render styles in this category are subclasses of :py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
-
-- :py:class:`KittyImage <term_image.image.KittyImage>`.
-
 
 Image Format Specification
 --------------------------

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -9,14 +9,59 @@ Reference
    exceptions
    utils
 
-Top-Level Functions
--------------------
+Top-Level Definitions
+---------------------
 
-.. autofunction:: term_image.get_font_ratio
+.. autoclass:: term_image.FontRatio
+   :show-inheritance:
+
+   .. autoattribute:: AUTO
+      :annotation:
+
+   .. autoattribute:: FULL_AUTO
+      :annotation:
 
 .. autofunction:: term_image.set_font_ratio
 
+.. autofunction:: term_image.get_font_ratio
+
 |
+
+
+.. _auto-font-ratio:
+
+Auto Font Ratio
+---------------
+
+When using **auto font ratio** (in either mode), it's important to note that some (not all) terminal emulators (e.g VTE-based ones) might have to be queried, which involves:
+
+  1. Clearing all unread input from the active terminal
+  2. Writing to the active terminal
+  3. Reading from the active terminal
+
+For this communication to be successful, it must not be interrupted.
+
+About #1
+   If this isn't a concern i.e the program will never expect any useful input, **particularly while an image's size is being set or when an image with** :ref:`unset size <unset-size>` **is being rendered**, then using ``FULL_AUTO`` mode is OK.
+
+   Otherwise i.e if the program will be expecting input:
+
+     * Use ``AUTO`` mode.
+     * Use :py:func:`utils.read_input() <term_image.utils.read_input>` (simply calling it without any argument is enough) to read all unread input (**without blocking**) before calling :py:func:`set_font_ratio() <term_image.set_font_ratio>`.
+
+About #2 and #3
+   If the program includes any other function that could write to the terminal OR especially, read from the terminal or modify it's attributes, while a query is in progress, decorate it with :py:func:`utils.lock_input <term_image.utils.lock_input>` to ensure it doesn't interfere.
+
+   For example, the TUI included in this package (i.e ``term_image``) uses `urwid <https://urwid.org>`_ which reads from the terminal using ``urwid.raw_display.Screen.get_available_raw_input()``. To prevent this method from interfering with terminal queries, it is wrapped thus::
+
+       urwid.raw_display.Screen.get_available_raw_input = lock_input(
+           urwid.raw_display.Screen.get_available_raw_input
+       )
+
+   Also, if the :term:`active terminal` is not the controlling terminal of the process using this library (e.g output is redirected to another terminal), ensure no process that can interfere with a query (e.g a shell) is currently running in the active terminal.
+
+   For instance, such a process can be temporarily put to sleep.
+
 
 .. _format-spec:
 

--- a/docs/source/viewer/config.rst
+++ b/docs/source/viewer/config.rst
@@ -43,8 +43,10 @@ checkers
 font ratio
    The :term:`font ratio`. [\*]
 
-   * Type: float
-   * Valid values: x > ``0.0``
+   * Type: null or float
+   * Valid values: ``null`` or x > ``0.0``
+
+   If ``null``, the ratio is determined from the :term:`active terminal` such that the proportion of any image is always correct. If this is not supported in the :term:`active terminal` or on the platform, ``0.5`` is used instead.
 
 getters
    Number of threads for downloading images from URL sources.

--- a/docs/source/viewer/index.rst
+++ b/docs/source/viewer/index.rst
@@ -42,26 +42,6 @@ The viewer can be used in two modes:
    | This mode is used whenever there are multiple image sources or at least one directory source, or when the ``--tui`` option is specified.
 
 
-Font Ratio
-----------
-
-The :term:`font ratio` is taken into consideration when setting image sizes for **text-based** render styles, in order for images drawn to the terminal to have correct proportion.
-
-| This value is determined by the :ref:`config option <font-ratio-config>` ``font ratio`` OR either of the command-line options ``-F | --font-ratio`` and ``--auto-font-ratio``.
-| The command-line options are mutually exclusive and override the config option.
-
-| By default (i.e without changing the config option value or specifying the command-line option), ``term-image`` tries to determine the value from the :term:`active terminal` which works on most mordern terminal emulators (currently supported on UNIX-like platforms only).
-| This is probably the best choice, except the terminal emulator or platform doesn't support this feature.
-
-| If ``term-image`` is unable to determine this value automatically, it falls back to ``0.5``, which is a reasonable value in most cases.
-| In case *auto* font ratio is not supported and the fallback value does not give expected results, a different value can be specified using the config or command-line option.
-
-.. attention::
-   If using *auto* font ratio and the :term:`active terminal` is not the controlling terminal of the `term-image` process (e.g output is redirected to another terminal), ensure no process that might read input (e.g a shell) is currently running in the active terminal, as such a process might interfere with determining the font ratio on some terminal emulators (e.g VTE-based ones).
-
-   For instance, the ``sleep`` command can be executed if a shell is currently running in the active terminal.
-
-
 Usage
 -----
 
@@ -86,6 +66,26 @@ See :ref:`render-styles`.
 | If the specified render style is text-based and not [fully] supported, a warning notification is emitted but execution still proceeds with the style.
 
 The ``--force-style`` command-line option can be used to bypass style support checks and force the usage of any style whether it's supported or not.
+
+
+Font Ratio
+----------
+
+The :term:`font ratio` is taken into consideration when setting image sizes for **text-based** render styles, in order for images drawn to the terminal to have correct proportion.
+
+| This value is determined by the :ref:`config option <font-ratio-config>` ``font ratio`` OR either of the command-line options ``-F | --font-ratio`` and ``--auto-font-ratio``.
+| The command-line options are mutually exclusive and override the config option.
+
+| By default (i.e without changing the config option value or specifying the command-line option), ``term-image`` tries to determine the value from the :term:`active terminal` which works on most mordern terminal emulators (currently supported on UNIX-like platforms only).
+| This is probably the best choice, except the terminal emulator or platform doesn't support this feature.
+
+| If ``term-image`` is unable to determine this value automatically, it falls back to ``0.5``, which is a reasonable value in most cases.
+| In case *auto* font ratio is not supported and the fallback value does not give expected results, a different value can be specified using the config or command-line option.
+
+.. attention::
+   If using *auto* font ratio and the :term:`active terminal` is not the controlling terminal of the `term-image` process (e.g output is redirected to another terminal), ensure no process that might read input (e.g a shell) is currently running in the active terminal, as such a process might interfere with determining the font ratio on some terminal emulators (e.g VTE-based ones).
+
+   For instance, the ``sleep`` command can be executed if a shell is currently running in the active terminal.
 
 
 Notifications

--- a/docs/source/viewer/index.rst
+++ b/docs/source/viewer/index.rst
@@ -47,16 +47,14 @@ Font Ratio
 
 The :term:`font ratio` is taken into consideration when setting image sizes for **text-based** render styles, in order for images drawn to the terminal to have correct proportion.
 
-This value is determined by the :ref:`config option <font-ratio-config>` ``font ratio`` and the command-line option ``-F | --font-ratio``.
+| This value is determined by the :ref:`config option <font-ratio-config>` ``font ratio`` OR either of the command-line options ``-F | --font-ratio`` and ``--auto-font-ratio``.
+| The command-line options are mutually exclusive and override the config option.
 
 | By default (i.e without changing the config option value or specifying the command-line option), ``term-image`` tries to determine the value from the :term:`active terminal` which works on most mordern terminal emulators (currently supported on UNIX-like platforms only).
 | This is probably the best choice, except the terminal emulator or platform doesn't support this feature.
 
 | If ``term-image`` is unable to determine this value automatically, it falls back to ``0.5``, which is a reasonable value in most cases.
 | In case *auto* font ratio is not supported and the fallback value does not give expected results, a different value can be specified using the config or command-line option.
-
-.. note::
-   Changing the config option from the default (``null``) completely disables automatic determination of font ratio.
 
 .. attention::
    If using *auto* font ratio and the :term:`active terminal` is not the controlling terminal of the `term-image` process (e.g output is redirected to another terminal), ensure no process that might read input (e.g a shell) is currently running in the active terminal, as such a process might interfere with determining the font ratio on some terminal emulators (e.g VTE-based ones).

--- a/docs/source/viewer/index.rst
+++ b/docs/source/viewer/index.rst
@@ -42,6 +42,28 @@ The viewer can be used in two modes:
    | This mode is used whenever there are multiple image sources or at least one directory source, or when the ``--tui`` option is specified.
 
 
+Font Ratio
+----------
+
+The :term:`font ratio` is taken into consideration when setting image sizes for **text-based** render styles, in order for images drawn to the terminal to have correct proportion.
+
+This value is determined by the :ref:`config option <font-ratio-config>` ``font ratio`` and the command-line option ``-F | --font-ratio``.
+
+| By default (i.e without changing the config option value or specifying the command-line option), ``term-image`` tries to determine the value from the :term:`active terminal` which works on most mordern terminal emulators (currently supported on UNIX-like platforms only).
+| This is probably the best choice, except the terminal emulator or platform doesn't support this feature.
+
+| If ``term-image`` is unable to determine this value automatically, it falls back to ``0.5``, which is a reasonable value in most cases.
+| In case *auto* font ratio is not supported and the fallback value does not give expected results, a different value can be specified using the config or command-line option.
+
+.. note::
+   Changing the config option from the default (``null``) completely disables automatic determination of font ratio.
+
+.. attention::
+   If using *auto* font ratio and the :term:`active terminal` is not the controlling terminal of the `term-image` process (e.g output is redirected to another terminal), ensure no process that might read input (e.g a shell) is currently running in the active terminal, as such a process might interfere with determining the font ratio on some terminal emulators (e.g VTE-based ones).
+
+   For instance, the ``sleep`` command can be executed if a shell is currently running in the active terminal.
+
+
 Usage
 -----
 

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -628,6 +628,17 @@ FOOTNOTES:
         help="Restore default config and exit (Overwrites the config file)",
     )
     general.add_argument(
+        "--style",
+        choices=("auto", "kitty", "term"),
+        default="auto",
+        help=(
+            "Specify the image render style (default: auto). "
+            'See "Render Styles" below'
+        ),
+    )
+
+    font_ratio_options = general.add_mutually_exclusive_group()
+    font_ratio_options.add_argument(
         "-F",
         "--font-ratio",
         type=float,
@@ -638,14 +649,10 @@ FOOTNOTES:
             f"correct image proportion (default: {config.font_ratio or 'auto'})"
         ),
     )
-    general.add_argument(
-        "--style",
-        choices=("auto", "kitty", "term"),
-        default="auto",
-        help=(
-            "Specify the image render style (default: auto). "
-            'See "Render Styles" below'
-        ),
+    font_ratio_options.add_argument(
+        "--auto-font-ratio",
+        action="store_true",
+        help="Determine the font ratio from the terminal, if possible",
     )
 
     mode_options = general.add_mutually_exclusive_group()
@@ -1078,6 +1085,8 @@ FOOTNOTES:
             )
             setattr(args, var_name, getattr(config, var_name))
 
+    if args.auto_font_ratio:
+        args.font_ratio = None
     try:
         set_font_ratio(args.font_ratio or FontRatio.FULL_AUTO)
     except TermImageException:

--- a/term_image/config.py
+++ b/term_image/config.py
@@ -194,6 +194,9 @@ def update_config(config: Dict[str, Any], old_version: str):
             ("['keys']['full-image']['Force Render'][1]", "F", "\u21e7F"),
             ("['keys']['full-grid-image']['Force Render'][1]", "F", "\u21e7F"),
         ],
+        "0.3": [
+            ("['font ratio']", 0.5, None),
+        ],
     }
 
     versions = tuple(changes)
@@ -318,7 +321,7 @@ def update_context_nav_keys(
 
 user_dir = os.path.join(os.path.expanduser("~"), ".term_image")
 config_file = os.path.join(user_dir, "config.json")
-version = "0.2"  # For config upgrades
+version = "0.3"  # For config upgrades
 
 _valid_keys = {*bytes(range(32, 127)).decode(), *urwid.escape._keyconv.values(), "esc"}
 _valid_keys.update(
@@ -368,7 +371,7 @@ valid_keys.extend(("page up", "ctrl page up", "page down", "ctrl page down"))
 _anim_cache = 100
 _cell_width = 30
 _checkers = None
-_font_ratio = 0.5
+_font_ratio = None
 _getters = 4
 _grid_renderers = 1
 _log_file = os.path.join(user_dir, "term_image.log")
@@ -495,8 +498,8 @@ config_options = {
         "must be `null` or a non-negative integer",
     ),
     "font ratio": (
-        lambda x: isinstance(x, float) and x > 0.0,
-        "must be a float greater than zero",
+        lambda x: x is None or isinstance(x, float) and x > 0.0,
+        "must be `null` or a float greater than zero",
     ),
     "getters": (
         lambda x: isinstance(x, int) and x > 0,

--- a/term_image/logging_multi.py
+++ b/term_image/logging_multi.py
@@ -7,7 +7,9 @@ import os
 from multiprocessing import JoinableQueue, Process
 from traceback import format_exception
 
-from . import cli, logging, notify
+import term_image
+
+from . import FontRatio, cli, logging, notify, set_font_ratio
 
 
 def process_multi_logs() -> None:
@@ -47,6 +49,7 @@ class Process(Process):
 
     def __init__(self, *args, redirect_notifs: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
+        self._font_ratio = cli.args.font_ratio
         self._log_queue = log_queue
         self._logging_details = {
             "constants": {
@@ -63,6 +66,11 @@ class Process(Process):
         _logger.debug("Starting")
 
         try:
+            if not self._font_ratio:
+                # Avoid error in case the terminal would not respond on time
+                term_image._auto_font_ratio = True
+            set_font_ratio(self._font_ratio or FontRatio.FULL_AUTO)
+
             super().run()
         except KeyboardInterrupt:
             # Log only if the main process was not interruped

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+import term_image
+
+
+def get_cell_size():
+    return cell_size
+
+
+def set_cell_size(size):
+    global cell_size
+
+    cell_size = size
+    term_image._auto_font_ratio = None
+
+
+cell_size = None
+term_image.get_cell_size = get_cell_size

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -1,7 +1,13 @@
+from operator import truediv
+from random import randint, random
+
 import pytest
 
+from term_image import FontRatio, get_font_ratio, set_font_ratio
+from term_image.exceptions import TermImageException
 from term_image.image import AutoImage, BaseImage, from_file
 
+from . import set_cell_size
 from .test_base import python_image, python_img
 
 
@@ -33,3 +39,51 @@ class TestConvinience:
             from_file(python_image, scale=1.0)
 
         assert isinstance(from_file(python_image), BaseImage)
+
+
+class TestFontRatio:
+    def test_args(self):
+        for value in (0, "1", ()):
+            with pytest.raises(TypeError, match=r"'ratio' must be"):
+                set_font_ratio(value)
+        for value in (0.0, -0.1, -1.0):
+            with pytest.raises(ValueError, match=r"'ratio' must be"):
+                set_font_ratio(value)
+
+        set_cell_size(None)
+        for value in FontRatio:
+            with pytest.raises(TermImageException):
+                set_font_ratio(value)
+
+    def test_fixed(self):
+        for value in (0.01, 0.1, 0.9, 0.99, 1.0, 2.0):
+            set_font_ratio(value)
+            assert get_font_ratio() == value
+
+        for _ in range(20):
+            value = random()
+            set_font_ratio(value)
+            assert get_font_ratio() == value
+
+    def test_auto(self):
+        set_cell_size((4, 9))
+        set_font_ratio(FontRatio.AUTO)
+        assert get_font_ratio() == 4 / 9 == get_font_ratio()
+
+        for _ in range(20):
+            cell_size = (randint(1, 20), randint(1, 20))
+            set_cell_size(cell_size)
+            set_font_ratio(FontRatio.AUTO)
+            assert get_font_ratio() == truediv(*cell_size) == get_font_ratio()
+            set_cell_size((0, 1))
+            assert get_font_ratio() == truediv(*cell_size)
+
+    def test_full_auto(self):
+        set_cell_size((4, 9))
+        set_font_ratio(FontRatio.FULL_AUTO)
+        assert get_font_ratio() == 4 / 9 == get_font_ratio()
+
+        for _ in range(20):
+            cell_size = (randint(1, 20), randint(1, 20))
+            set_cell_size(cell_size)
+            assert get_font_ratio() == truediv(*cell_size) == get_font_ratio()

--- a/vim-style_config.json
+++ b/vim-style_config.json
@@ -1,9 +1,9 @@
 {
-    "version": "0.2",
+    "version": "0.3",
     "anim cache": 100,
     "cell width": 30,
     "checkers": null,
-    "font ratio": 0.5,
+    "font ratio": null,
     "getters": 4,
     "grid renderers": 1,
     "log file": "/home/anonymoux47/.term_image/term_image.log",


### PR DESCRIPTION
- Implements automatic font ratio computation.
- Adds `term_image.FontRatio` enumeration class.
- Improves proportioning of text-based images in the CLI and TUI.
- Changes default value of `font ratio` config option to `null`.
- Adds `--auto-font-ratio` CL option.
- Updates library and viewer docs.