### PR TITLE
API Renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `BaseImage.source` now raises `TermImageException` when invoked after the instance has been finalized ([#38]).
 - [lib] Improved `repr()` of image instances ([#38]).
 - [lib] Direct baseclass of `TermImage` to `TextImage` ([#44]).
+- [lib] `TermImage` to `BlockImage` ([#46]).
+- [lib] Exception naming scheme ([#46]).
+  - `TermImageException` to `TermImageError`.
+  - `InvalidSize` to `InvalidSizError`.
 - [cli] `-S` from `--scroll` to `--style` ([#44]).
 - [cli,tui] Changed default value of `font ratio` config option to `null` ([#45]).
+
+### Deprecated
+- [lib] `term_image.image.TermImage` ([#46]).
+- [lib] `TermImageException` and `InvalidSize` in `term_image.exceptions` ([#46]).
 
 [#34]: https://github.com/AnonymouX47/term-image/pull/34
 [#36]: https://github.com/AnonymouX47/term-image/pull/36
@@ -53,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#43]: https://github.com/AnonymouX47/term-image/pull/43
 [#44]: https://github.com/AnonymouX47/term-image/pull/44
 [#45]: https://github.com/AnonymouX47/term-image/pull/45
+[#46]: https://github.com/AnonymouX47/term-image/pull/46
 
 
 ## [0.3.1] - 2022-05-04

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint:
 # Executing using `python -m` adds CWD to `sys.path`.
 
 test: test-base test-iterator test-others test-text test-graphics
-test-text: test-term
+test-text: test-block
 test-graphics: test-kitty
 
 test-base:
@@ -45,8 +45,8 @@ test-others:
 test-kitty:
 	python -m pytest -v tests/test_kitty.py
 
-test-term:
-	python -m pytest -v tests/test_term.py
+test-block:
+	python -m pytest -v tests/test_block.py
 
 test-url:
 	python -m pytest -v tests/test_url.py

--- a/docs/source/library/index.rst
+++ b/docs/source/library/index.rst
@@ -19,7 +19,7 @@ Known Issues
 
    * **Comment**: First of all, the issue is inherent to these shells and neither a fault of this library nor the Windows Terminal, as drawing images and animations works properly with WSL within Windows Terminal.
 
-   * **Solution**: A workaround is to leave some **horizontal allowance** of **at least two columns** to ensure the image never reaches the right edge of the terminal. This can be achieved in the library by using the *h_allow* parameter of :py:meth:`TermImage.set_size() <term_image.image.TermImage.set_size>`.
+   * **Solution**: A workaround is to leave some **horizontal allowance** of **at least two columns** to ensure the image never reaches the right edge of the terminal. This can be achieved in the library by using the *h_allow* parameter of :py:meth:`set_size() <term_image.image.BaseImage.set_size>`.
 
 
 .. _library-planned:

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -43,6 +43,10 @@ Core Library Definitions
       :members:
       :show-inheritance:
 
+   .. autoclass:: BlockImage
+      :members:
+      :show-inheritance:
+
    .. autoclass:: KittyImage
       :members:
       :show-inheritance:
@@ -62,20 +66,20 @@ Core Library Definitions
 Context Management Protocol Support
 -----------------------------------
 
-``TermImage`` instances are context managers i.e they can be used with the ``with`` statement as in::
+``BaseImage`` instances are context managers i.e they can be used with the ``with`` statement as in::
 
-   with TermImage.from_url(url) as image:
+   with from_url(url) as image:
        ...
 
-Using an instance as a context manager more surely guarantees **object finalization** (i.e clean-up/release of resources), especially for instances with URL sources (see :py:meth:`TermImage.from_url`).
+Using an instance as a context manager more surely guarantees **object finalization** (i.e clean-up/release of resources), especially for instances with URL sources (see :py:meth:`BaseImage.from_url`).
 
 
 Iteration Support
 -----------------
 
-:term:`Animated` ``TermImage`` instances are iterable i.e they can be used with the ``for`` statement (and other means of iteration such as unpacking) as in::
+:term:`Animated` ``BaseImage`` instances are iterable i.e they can be used with the ``for`` statement (and other means of iteration such as unpacking) as in::
 
-   for frame in TermImage.from_file("animated.gif"):
+   for frame in from_file("animated.gif"):
        ...
 
 Subsequent frames of the image are yielded on subsequent iterations.

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -49,7 +49,7 @@ Represent images using ASCII or Unicode symbols, and in some cases, in conjuncti
 
 Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
 
-- :py:class:`TermImage <term_image.image.TermImage>`.
+- :py:class:`BlockImage <term_image.image.BlockImage>`.
 
 Graphics-based Render Styles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +139,7 @@ Image Format Specification
 
     * The value must be in the range **0.0 <= threshold < 1.0**.
     * **Applies to only text-based render styles**, (i.e those not based on terminal
-      graphics protocols) e.g. :py:class:`TermImage <term_image.image.TermImage>`.
+      graphics protocols) e.g. :py:class:`BlockImage <term_image.image.BlockImage>`.
 
   * ``bgcolor``: Hex color with which transparent background should be replaced e.g ``ffffff``, ``7faa52``.
   * If neither ``threshold`` nor ``bgcolor`` is present, but ``#`` is present, transparency is disabled (uses the image's default background color, or black if none).

--- a/docs/source/library/tutorial.rst
+++ b/docs/source/library/tutorial.rst
@@ -16,23 +16,23 @@ Creating an instance
 
 If the file is stored on your local filesystem::
 
-   from term_image.image import TermImage
+   from term_image.image import BlockImage
 
-   image = TermImage.from_file("python.png")
+   image = BlockImage.from_file("python.png")
 
 You can also use a URL if you don't have the file stored locally::
 
-   from term_image.image import TermImage
+   from term_image.image import BlockImage
 
-   image = TermImage.from_url("https://raw.githubusercontent.com/AnonymouX47/term-image/docs/source/resources/python.png")
+   image = BlockImage.from_url("https://raw.githubusercontent.com/AnonymouX47/term-image/docs/source/resources/python.png")
 
 The library can also be used with PIL images::
 
    from PIL import Image
-   from term_image.image import TermImage
+   from term_image.image import BlockImage
 
    img = Image.open("python.png")
-   image = TermImage(img)
+   image = BlockImage(img)
 
 
 Rendering an image
@@ -137,12 +137,12 @@ Drawing/Displaying an image to/in the terminal
 
 There are two ways to draw an image to the terminal screen:
 
-1. The :py:meth:`draw() <term_image.image.TermImage.draw>` method
+1. The :py:meth:`draw() <term_image.image.BaseImage.draw>` method
    ::
 
       image.draw()
 
-   **NOTE:** :py:meth:`TermImage.draw() <term_image.image.TermImage.draw>` has various parameters for :term:`alignment`/:term:`padding`, transparency and animation control.
+   **NOTE:** :py:meth:`draw() <term_image.image.BaseImage.draw>` has various parameters for :term:`alignment`/:term:`padding`, transparency and animation control.
 
 2. Using ``print()`` with an image render output (i.e printing the rendered string)
 
@@ -157,7 +157,7 @@ There are two ways to draw an image to the terminal screen:
       print(f"{image:>200.^70#ffffff}")  # Uses format()
 
 .. note::
-   - For :term:`animated` images, only the former animates the output, the latter only draws the **current** frame (see :py:meth:`TermImage.seek() <term_image.image.TermImage.seek()>` and :py:meth:`TermImage.tell() <term_image.image.TermImage.tell()>`).
+   - For :term:`animated` images, only the former animates the output, the latter only draws the **current** frame (see :py:meth:`seek() <term_image.image.BaseImage.seek()>` and :py:meth:`tell() <term_image.image.BaseImage.tell()>`).
    - Also, the former performs size validation to see if the image will fit into the terminal, while the latter doesn't.
 
 
@@ -167,7 +167,7 @@ There are two ways to draw an image to the terminal screen:
 Image size
 ----------
 | The size of an image is the **unscaled** dimension with which an image is rendered.
-| The image size can be retrieved via the :py:attr:`size <term_image.image.TermImage.size>`, :py:attr:`width <term_image.image.TermImage.width>` and :py:attr:`height <term_image.image.TermImage.height>` properties.
+| The image size can be retrieved via the :py:attr:`size <term_image.image.BaseImage.size>`, :py:attr:`width <term_image.image.BaseImage.width>` and :py:attr:`height <term_image.image.BaseImage.height>` properties.
 
 The size of an image can be in either of two states:
 
@@ -194,15 +194,15 @@ The size of an image can be in either of two states:
 
 For example:
 
->>> image = Termimage.from_file("python.png")  # Unset
+>>> image = BlockImage.from_file("python.png")  # Unset
 >>> image.size is None
 True
->>> image = TermImage.from_file("python.png", width=60)  # width is given
+>>> image = BlockImage.from_file("python.png", width=60)  # width is given
 >>> image.size
 (60, 60)
 >>> image.height
 60
->>> image = TermImage.from_file("python.png", height=56)  # height is given
+>>> image = BlockImage.from_file("python.png", height=56)  # height is given
 >>> image.size
 (56, 56)
 >>> image.width
@@ -210,25 +210,25 @@ True
 
 No size validation is performed i.e the resulting size might not fit into the terminal window
 
->>> image = TermImage.from_file("python.png", height=136)  # (terminal_height - 2) * 2; Will fit, OK
+>>> image = BlockImage.from_file("python.png", height=136)  # (terminal_height - 2) * 2; Will fit, OK
 >>> image.size
 (136, 136)
->>> image = TermImage.from_file("python.png", height=1000)  # Will not fit, also OK
+>>> image = BlockImage.from_file("python.png", height=1000)  # Will not fit, also OK
 >>> image.size
 (1000, 1000)
 
 An exception is raised when both *width* and *height* are given.
 
->>> image = TermImage.from_file("python.png", width=100, height=100)
+>>> image = BlockImage.from_file("python.png", width=100, height=100)
 Traceback (most recent call last):
   .
   .
   .
 ValueError: Cannot specify both width and height
 
-The :py:attr:`width <term_image.image.TermImage.width>` and :py:attr:`height <term_image.image.TermImage.height>` properties are used to set the size of an image after instantiation.
+The :py:attr:`width <term_image.image.BaseImage.width>` and :py:attr:`height <term_image.image.BaseImage.height>` properties are used to set the size of an image after instantiation.
 
->>> image = Termimage.from_file("python.png")  # Unset
+>>> image = BlockImage.from_file("python.png")  # Unset
 >>> image.size is None
 True
 >>> image.width = 56
@@ -245,7 +245,7 @@ True
 
 Setting ``width`` or ``height`` to ``None`` sets the size to that automatically calculated based on the current :term:`terminal size`.
 
->>> image = Termimage.from_file("python.png")  # Unset
+>>> image = BlockImage.from_file("python.png")  # Unset
 >>> image.size is None
 True
 >>> image.width = None
@@ -260,9 +260,9 @@ True
 
 .. note:: An exception is raised if the terminal size is too small to calculate a size.
 
-The :py:attr:`size <term_image.image.TermImage.size>` property can only be set to one value, ``None`` and doing this :ref:`unsets <unset-size>` the image size.
+The :py:attr:`size <term_image.image.BaseImage.size>` property can only be set to one value, ``None`` and doing this :ref:`unsets <unset-size>` the image size.
 
->>> image = Termimage.from_file("python.png", width=100)
+>>> image = BlockImage.from_file("python.png", width=100)
 >>> image.size
 (100, 100)
 >>> image.size = None
@@ -278,7 +278,7 @@ True
 
 .. hint::
 
-   See :py:meth:`TermImage.set_size() <term_image.image.TermImage.set_size()>` for extended sizing control.
+   See :py:meth:`set_size() <term_image.image.BaseImage.set_size()>` for extended sizing control.
 
 
 .. _image-scale:
@@ -289,11 +289,11 @@ Image scale
 | The scale of an image is the **fraction** of the size that'll actually be used to render the image.
 | A valid scale value is a ``float`` in the range ``0 < x <= 1`` i.e greater than zero and less than or equal to one.
 
-The image scale can be retrieved via the properties :py:attr:`scale <term_image.image.TermImage.scale>`, :py:attr:`scale_x <term_image.image.TermImage.scale_x>` and :py:attr:`scale_y <term_image.image.TermImage.scale_y>`.
+The image scale can be retrieved via the properties :py:attr:`scale <term_image.image.BaseImage.scale>`, :py:attr:`scale_x <term_image.image.BaseImage.scale_x>` and :py:attr:`scale_y <term_image.image.BaseImage.scale_y>`.
 
 The scale can be set at instantiation by passing a value to the *scale* **keyword-only** paramter.
 
->>> image = Termimage.from_file("python.png", scale=(0.75, 0.6))
+>>> image = BlockImage.from_file("python.png", scale=(0.75, 0.6))
 >>> image.scale
 >>> (0.75, 0.6)
 
@@ -303,7 +303,7 @@ The rendered result (using ``image.draw()``) should look like:
 
 If the *scale* argument is ommited, the default scale ``(1.0, 1.0)`` is used.
 
->>> image = Termimage.from_file("python.png")
+>>> image = BlockImage.from_file("python.png")
 >>> image.scale
 >>> (1.0, 1.0)
 
@@ -311,12 +311,12 @@ The rendered result (using ``image.draw()``) should look like:
 
 .. image:: /resources/tutorial/scale_unset.png
 
-| The properties :py:attr:`scale <term_image.image.TermImage.scale>`, :py:attr:`scale_x <term_image.image.TermImage.scale_x>` and :py:attr:`scale_y <term_image.image.TermImage.scale_y>` are used to set the scale of an image after instantiation.
+| The properties :py:attr:`scale <term_image.image.BaseImage.scale>`, :py:attr:`scale_x <term_image.image.BaseImage.scale_x>` and :py:attr:`scale_y <term_image.image.BaseImage.scale_y>` are used to set the scale of an image after instantiation.
 
 | ``scale`` accepts a tuple of two scale values or a single scale value.
 | ``scale_x`` and ``scale_y`` each accept a single scale value.
 
->>> image = Termimage.from_file("python.png")
+>>> image = BlockImage.from_file("python.png")
 >>> image.scale = (.3, .56756)
 >>> image.scale
 (0.3, 0.56756)

--- a/term_image/__init__.py
+++ b/term_image/__init__.py
@@ -26,7 +26,7 @@ from enum import Enum, auto
 from operator import truediv
 from typing import Union
 
-from .exceptions import TermImageException
+from .exceptions import TermImageError
 from .utils import get_cell_size
 
 version_info = (0, 4, 0, "dev0")
@@ -61,7 +61,7 @@ def set_font_ratio(ratio: Union[float, FontRatio]) -> None:
         TypeError: An argument is of an inappropriate type.
         ValueError: An argument is of an appropriate type but has an
           unexpected/invalid value.
-        term_image.exceptions.TermImageException: Auto font ratio is not supported
+        term_image.exceptions.TermImageError: Auto font ratio is not supported
           in the :term:`active terminal` or on the current platform.
 
     This value is taken into consideration when setting image sizes for **text-based**
@@ -83,7 +83,7 @@ def set_font_ratio(ratio: Union[float, FontRatio]) -> None:
             _auto_font_ratio = get_cell_size() is not None
 
         if not _auto_font_ratio:
-            raise TermImageException(
+            raise TermImageError(
                 "Auto font ratio is not supported in the active terminal or on the "
                 "current platform"
             )

--- a/term_image/__main__.py
+++ b/term_image/__main__.py
@@ -91,8 +91,7 @@ def main() -> int:
         return exit_code
     finally:
         # Explicit cleanup is neccessary since the top-level `Image` widgets
-        # (and by implication, `TermImage` instances) will probably still have
-        # references to them hidden deep somewhere :)
+        # will still hold references to the `BaseImage` instances
         if cli.url_images is not None:
             for _, value in cli.url_images:
                 value._image.close()

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -20,7 +20,7 @@ import requests
 
 from . import FontRatio, __version__, config, logging, notify, set_font_ratio, tui
 from .config import config_options, store_config
-from .exceptions import TermImageException, URLNotFoundError
+from .exceptions import TermImageError, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
 from .image import BlockImage, KittyImage, _best_style
 from .image.common import _ALPHA_THRESHOLD
@@ -1094,7 +1094,7 @@ FOOTNOTES:
         args.font_ratio = None
     try:
         set_font_ratio(args.font_ratio or FontRatio.FULL_AUTO)
-    except TermImageException:
+    except TermImageError:
         notify.notify(
             "Auto font ratio is not supported in the active terminal or on this "
             "platform, using 0.5. It can be set otherwise using `-F | --font-ratio`.",
@@ -1112,7 +1112,7 @@ FOOTNOTES:
     else:
         try:
             ImageClass(None)
-        except TermImageException:  # Instantiation isn't permitted
+        except TermImageError:  # Instantiation isn't permitted
             log(
                 f"The {style!r} render style is not supported in the current "
                 "terminal! To use it anyways, add '--force-style'.",
@@ -1295,7 +1295,7 @@ FOOTNOTES:
                     check_size=not args.oversize,
                 )
 
-            # Handles `ValueError` and `.exceptions.InvalidSize`
+            # Handles `ValueError` and `.exceptions.InvalidSizeError`
             # raised by `BaseImage.set_size()`, scaling value checks
             # or padding width/height checks.
             except ValueError as e:

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -22,7 +22,7 @@ from . import FontRatio, __version__, config, logging, notify, set_font_ratio, t
 from .config import config_options, store_config
 from .exceptions import TermImageException, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
-from .image import KittyImage, TermImage, _best_style
+from .image import BlockImage, KittyImage, _best_style
 from .image.common import _ALPHA_THRESHOLD
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
@@ -573,7 +573,7 @@ Render Styles:
         include (but might not be limited to):
         - Kitty >= 0.20.0
         - Konsole >= 22.04.0
-    term: Uses unicode half blocks with 24-bit color escape codes to represent images
+    block: Uses unicode half blocks with 24-bit color escape codes to represent images
         with a density of two pixels per character cell.
 
     Using a terminal-graphics-based style not supported by the active terminal is not
@@ -630,7 +630,7 @@ FOOTNOTES:
     general.add_argument(
         "-S",
         "--style",
-        choices=("auto", "kitty", "term"),
+        choices=("auto", "kitty", "block"),
         default="auto",
         help='Image render style (default: auto). See "Render Styles" below',
     )
@@ -1102,7 +1102,7 @@ FOOTNOTES:
         )
         args.font_ratio = 0.5
 
-    ImageClass = {"auto": None, "kitty": KittyImage, "term": TermImage}[args.style]
+    ImageClass = {"auto": None, "kitty": KittyImage, "block": BlockImage}[args.style]
     if not ImageClass:
         ImageClass = _best_style()
 

--- a/term_image/exceptions.py
+++ b/term_image/exceptions.py
@@ -6,13 +6,21 @@ Custom Exceptions
 from __future__ import annotations
 
 
-class TermImageException(Exception):
-    """Package exception baseclass"""
+class TermImageError(Exception):
+    """Exception baseclass. Raised for generic errors."""
 
 
-class URLNotFoundError(FileNotFoundError, TermImageException):
-    """Raised for 404 errors"""
+class TermImageException(TermImageError):
+    """*Deprecated since version 0.4.0:* Replaced by :py:class:`TermImageError`."""
 
 
-class InvalidSize(ValueError, TermImageException):
-    """Raised for invalid image sizes"""
+class URLNotFoundError(FileNotFoundError, TermImageError):
+    """Raised for 404 errors."""
+
+
+class InvalidSizeError(ValueError, TermImageError):
+    """Raised for invalid image sizes."""
+
+
+class InvalidSize(InvalidSizeError):
+    """*Deprecated since version 0.4.0:* Replaced by :py:class:`InvalidSizeError`."""

--- a/term_image/image/__init__.py
+++ b/term_image/image/__init__.py
@@ -12,6 +12,7 @@ __all__ = (
     "BaseImage",
     "GraphicsImage",
     "TextImage",
+    "BlockImage",
     "KittyImage",
     "TermImage",
     "ImageIterator",
@@ -21,6 +22,7 @@ from typing import Optional, Tuple, Union
 
 import PIL
 
+from .block import BlockImage, TermImage  # noqa:F401
 from .common import (  # noqa:F401
     BaseImage,
     GraphicsImage,
@@ -29,7 +31,6 @@ from .common import (  # noqa:F401
     TextImage,
 )
 from .kitty import KittyImage  # noqa:F401
-from .term import TermImage  # noqa:F401
 
 
 def AutoImage(
@@ -85,4 +86,4 @@ def _best_style():
 
 
 # In order of preference
-_styles = (KittyImage, TermImage)
+_styles = (KittyImage, BlockImage)

--- a/term_image/image/block.py
+++ b/term_image/image/block.py
@@ -155,7 +155,7 @@ class BlockImage(TextImage):
 
 
 class TermImage(BlockImage):
-    """Deprecated alias of :py:class:`BlockImage`."""
+    """*Deprecated since version 0.4.0:* Replaced by :py:class:`BlockImage`."""
 
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/term_image/image/block.py
+++ b/term_image/image/block.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-__all__ = ("TermImage",)
+__all__ = ("BlockImage", "TermImage")
 
 import io
 import os
+import warnings
 from math import ceil
 from operator import mul
 from typing import Optional, Tuple, Union
@@ -13,11 +14,13 @@ import PIL
 from ..utils import _BG_FMT, _FG_FMT, _RESET
 from .common import TextImage
 
+warnings.filterwarnings("once", category=DeprecationWarning, module=__name__)
+
 _LOWER_PIXEL = "\u2584"  # lower-half block element
 _UPPER_PIXEL = "\u2580"  # upper-half block element
 
 
-class TermImage(TextImage):
+class BlockImage(TextImage):
     """A render style using unicode half blocks and ANSI 24-bit colour escape codes.
 
     See :py:class:`TextImage` for the description of the constructor.
@@ -149,3 +152,15 @@ class TermImage(TextImage):
 
         with buffer:
             return buffer.getvalue()
+
+
+class TermImage(BlockImage):
+    """Deprecated alias of :py:class:`BlockImage`."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "`TermImage` has been deprecated and will be removed in version 1.0.0, "
+            "use `BlockImage` instead.",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ import pytest
 from PIL import Image
 
 from term_image import set_font_ratio
-from term_image.exceptions import TermImageException
+from term_image.exceptions import TermImageError
 from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, TextImage
 from term_image.utils import get_terminal_size
 
@@ -112,7 +112,7 @@ def test_instantiation_Graphics():
         ImageClass._supported = True
         assert isinstance(ImageClass(python_img), GraphicsImage)
         ImageClass._supported = False
-        with pytest.raises(TermImageException):
+        with pytest.raises(TermImageError):
             ImageClass(python_img)
     finally:
         ImageClass._supported = original

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,7 @@ from PIL import Image, UnidentifiedImageError
 
 from term_image import set_font_ratio
 from term_image.exceptions import InvalidSize, TermImageException
-from term_image.image import ImageIterator, ImageSource, TermImage
+from term_image.image import BlockImage, ImageIterator, ImageSource
 
 from .common import _size, columns, lines, python_img, setup_common
 
@@ -19,7 +19,7 @@ python_sym = "tests/images/python_sym.png"  # Symlink to "python.png"
 anim_img = Image.open("tests/images/lion.gif")
 stdout = io.StringIO()
 
-setup_common(TermImage)
+setup_common(BlockImage)
 from .common import _height, _width  # noqa:E402
 
 
@@ -31,20 +31,20 @@ def clear_stdout():
 class TestConstructor:
     def test_args(self):
         with pytest.raises(TypeError, match=r"'PIL\.Image\.Image' instance"):
-            TermImage(python_image)
+            BlockImage(python_image)
 
         # Ensure size arguments get through to `set_size()`
         with pytest.raises(ValueError, match=r".* both width and height"):
-            TermImage(python_img, width=1, height=1)
+            BlockImage(python_img, width=1, height=1)
 
         with pytest.raises(TypeError, match=r"'scale'"):
-            TermImage(python_img, scale=0.5)
+            BlockImage(python_img, scale=0.5)
         for value in ((0.0, 0.0), (-0.4, -0.4)):
             with pytest.raises(ValueError, match=r"'scale'"):
-                TermImage(python_img, scale=value)
+                BlockImage(python_img, scale=value)
 
     def test_init(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image._size is None
         assert isinstance(image._scale, list)
         assert image._scale == [1.0, 1.0]
@@ -53,18 +53,18 @@ class TestConstructor:
         assert isinstance(image._original_size, tuple)
         assert image._original_size == python_img.size
 
-        image = TermImage(python_img, width=_size)
+        image = BlockImage(python_img, width=_size)
         assert isinstance(image._size, tuple)
-        image = TermImage(python_img, height=_size)
+        image = BlockImage(python_img, height=_size)
         assert isinstance(image._size, tuple)
 
-        image = TermImage(python_img, scale=(0.5, 0.4))
+        image = BlockImage(python_img, scale=(0.5, 0.4))
         assert image._scale == [0.5, 0.4]
 
         assert image._is_animated is False
 
     def test_init_animated(self):
-        image = TermImage(anim_img)
+        image = BlockImage(anim_img)
         assert image._is_animated is True
         assert image._frame_duration == (anim_img.info.get("duration") or 100) / 1000
         assert image._seek_position == 0
@@ -72,7 +72,7 @@ class TestConstructor:
 
         try:
             anim_img.seek(2)
-            assert TermImage(anim_img)._seek_position == 2
+            assert BlockImage(anim_img)._seek_position == 2
         finally:
             anim_img.seek(0)
 
@@ -80,25 +80,25 @@ class TestConstructor:
 class TestFromFile:
     def test_args(self):
         with pytest.raises(TypeError, match=r"a string"):
-            TermImage.from_file(python_img)
+            BlockImage.from_file(python_img)
         with pytest.raises(FileNotFoundError):
-            TermImage.from_file(python_image + "e")
+            BlockImage.from_file(python_image + "e")
         with pytest.raises(IsADirectoryError):
-            TermImage.from_file("tests")
+            BlockImage.from_file("tests")
         with pytest.raises(UnidentifiedImageError):
-            TermImage.from_file("LICENSE")
+            BlockImage.from_file("LICENSE")
 
         # Ensure size arguments get through
         with pytest.raises(ValueError, match=r"both width and height"):
-            TermImage.from_file(python_image, width=1, height=1)
+            BlockImage.from_file(python_image, width=1, height=1)
 
         # Ensure scale argument gets through
         with pytest.raises(TypeError, match=r"'scale'"):
-            TermImage.from_file(python_image, scale=1.0)
+            BlockImage.from_file(python_image, scale=1.0)
 
     def test_filepath(self):
-        image = TermImage.from_file(python_image)
-        assert isinstance(image, TermImage)
+        image = BlockImage.from_file(python_image)
+        assert isinstance(image, BlockImage)
         assert image._source == os.path.abspath(python_image)
         assert image._source_type is ImageSource.FILE_PATH
 
@@ -108,15 +108,15 @@ class TestFromFile:
         "doesn't support symlinks",
     )
     def test_symlink(self):
-        image = TermImage.from_file(python_sym)
-        assert isinstance(image, TermImage)
+        image = BlockImage.from_file(python_sym)
+        assert isinstance(image, BlockImage)
         assert image._source == os.path.abspath(python_sym)
         assert image._source_type is ImageSource.FILE_PATH
 
 
 class TestProperties:
     def test_closed(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert not image.closed
 
         with pytest.raises(AttributeError):
@@ -126,12 +126,12 @@ class TestProperties:
         assert image.closed
 
     def test_frame_duration(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image.frame_duration is None
         image.frame_duration = 0.5
         assert image.frame_duration is None
 
-        image = TermImage(anim_img)
+        image = BlockImage(anim_img)
         assert image._frame_duration == (anim_img.info.get("duration") or 100) / 1000
 
         for duration in (0, 1, "0.1", "1", 0.3j):
@@ -145,20 +145,20 @@ class TestProperties:
         assert image.frame_duration == 0.5
 
     def test_is_animated(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert not image.is_animated
 
-        image = TermImage(anim_img)
+        image = BlockImage(anim_img)
         assert image.is_animated
 
         with pytest.raises(AttributeError):
             image.is_animated = False
 
     def test_n_frames(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image.n_frames == 1
 
-        image = TermImage(anim_img)
+        image = BlockImage(anim_img)
         assert 1 < image.n_frames == anim_img.n_frames
         assert image.n_frames == anim_img.n_frames  # Ensure consistency
 
@@ -166,7 +166,7 @@ class TestProperties:
             image.n_frames = 2
 
     def test_rendered_size_height_width(self):
-        image = TermImage(python_img)  # Square
+        image = BlockImage(python_img)  # Square
 
         with pytest.raises(AttributeError):
             image.rendered_size = (_size,) * 2
@@ -211,7 +211,7 @@ class TestProperties:
             set_font_ratio(0.5)
 
     def test_scale_value_checks(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
 
         # Value type
         for value in (0, 1, None, "1", "1.0"):
@@ -255,7 +255,7 @@ class TestProperties:
                 image.scale = value
 
     def test_scale_x_y(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image.scale == (1.0, 1.0)
         assert image.scale_x == image.scale_y == 1.0
 
@@ -276,7 +276,7 @@ class TestProperties:
         assert image.scale_x == 0.25
 
     def test_size_height_width(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image.original_size == python_img.size
         assert image.size is image.height is image.width is None
 
@@ -299,11 +299,11 @@ class TestProperties:
         assert image.size is image.height is image.width is None
 
     def test_source(self):
-        image = TermImage(python_img)
+        image = BlockImage(python_img)
         assert image.source is python_img
         assert image.source_type is ImageSource.PIL_IMAGE
 
-        image = TermImage.from_file(python_image)
+        image = BlockImage.from_file(python_image)
         assert image.source == os.path.abspath(python_image)
         assert image.source_type is ImageSource.FILE_PATH
 
@@ -316,7 +316,7 @@ class TestProperties:
         "doesn't support symlinks",
     )
     def test_source_symlink(self):
-        image = TermImage.from_file(python_sym)
+        image = BlockImage.from_file(python_sym)
         assert os.path.basename(image.source) == "python_sym.png"
         assert (
             image.source == os.path.abspath(python_sym) != os.path.realpath(python_sym)
@@ -325,7 +325,7 @@ class TestProperties:
 
 
 def test_close():
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
     image.close()
     assert image.closed
     with pytest.raises(AttributeError):
@@ -341,18 +341,18 @@ def test_close():
 
 
 def test_context_management():
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
     with image as image2:
         assert image2 is image
     assert image.closed
 
 
 def test_iter():
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
     with pytest.raises(ValueError, match="not animated"):
         iter(image)
 
-    anim_image = TermImage(anim_img)
+    anim_image = BlockImage(anim_img)
     image_it = iter(anim_image)
     assert isinstance(image_it, ImageIterator)
     assert image_it._image is anim_image
@@ -360,7 +360,7 @@ def test_iter():
 
 def test_seek_tell():
     # Non-animated
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
     assert image.tell() == 0
     image.seek(0)
     assert image.tell() == 0
@@ -369,7 +369,7 @@ def test_seek_tell():
     assert image.tell() == 0
 
     # Animated
-    image = TermImage(anim_img)
+    image = BlockImage(anim_img)
     assert image.tell() == 0
     n_frames = anim_img.n_frames
 
@@ -392,9 +392,9 @@ def test_seek_tell():
 
 
 class TestSetSize:
-    image = TermImage(python_img)  # Square
-    h_image = TermImage.from_file("tests/images/hori.jpg")  # Horizontally-oriented
-    v_image = TermImage.from_file("tests/images/vert.jpg")  # Vertically-oriented
+    image = BlockImage(python_img)  # Square
+    h_image = BlockImage.from_file("tests/images/hori.jpg")  # Horizontally-oriented
+    v_image = BlockImage.from_file("tests/images/vert.jpg")  # Vertically-oriented
 
     def test_args_width_height(self):
         with pytest.raises(ValueError, match=".* both width and height"):
@@ -465,7 +465,7 @@ def test_renderer():
     def test(img, *args, **kwargs):
         return img, args, kwargs
 
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
 
     for positionals, keywords in (
         ((), {}),
@@ -481,7 +481,7 @@ def test_renderer():
 class TestRender:
     # Fully transparent image
     # It's easy to predict it's pixel values
-    trans = TermImage.from_file("tests/images/trans.png")
+    trans = BlockImage.from_file("tests/images/trans.png")
 
     def render_image(self, alpha):
         return self.trans._renderer(lambda im: self.trans._render_image(im, alpha))
@@ -503,7 +503,7 @@ class TestRender:
 # size of the render results), then testing formatting with a single style should
 # suffice.
 class TestFormatting:
-    image = TermImage(python_img)
+    image = BlockImage(python_img)
     image.scale = 0.5  # To ensure there's padding
     render = str(image)
     check_formatting = image._check_formatting
@@ -753,8 +753,8 @@ class TestFormatting:
 # Testing with one style should suffice for all since it's simply testing the method
 # and nothing perculiar to the style
 class TestDraw:
-    image = TermImage(python_img, width=_size)
-    anim_image = TermImage(anim_img, width=_size)
+    image = BlockImage(python_img, width=_size)
+    anim_image = BlockImage(anim_img, width=_size)
 
     def test_args(self):
         sys.stdout = stdout
@@ -810,8 +810,8 @@ class TestDraw:
             self.image.draw()
 
     class TestNonAnimated:
-        image = TermImage(python_img, width=_size)
-        anim_image = TermImage(anim_img, width=_size)
+        image = BlockImage(python_img, width=_size)
+        anim_image = BlockImage(anim_img, width=_size)
 
         def test_fit_to_width(self):
             sys.stdout = stdout
@@ -838,8 +838,8 @@ class TestDraw:
             clear_stdout()
 
     class TestAnimatedFalse:
-        image = TermImage(python_img, width=_size)
-        anim_image = TermImage(anim_img, width=_size)
+        image = BlockImage(python_img, width=_size)
+        anim_image = BlockImage(anim_img, width=_size)
 
         def test_fit_to_width(self):
             sys.stdout = stdout
@@ -866,8 +866,8 @@ class TestDraw:
             clear_stdout()
 
     class TestAnimated:
-        image = TermImage(python_img)
-        anim_image = TermImage(anim_img)
+        image = BlockImage(python_img)
+        anim_image = BlockImage(anim_img)
 
         def test_fit_to_width(self):
             sys.stdout = stdout

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,10 +1,10 @@
-"""TermImage-specific tests"""
+"""BlockImage-specific tests"""
 
 from random import random
 
 import pytest
 
-from term_image.image import TermImage
+from term_image.image import BlockImage
 from term_image.image.common import _ALPHA_THRESHOLD
 
 from .common import *  # noqa:F401
@@ -17,13 +17,13 @@ for name in tuple(globals()):
 
 @pytest.mark.order("first")
 def test_setup_common():
-    setup_common(TermImage)
+    setup_common(BlockImage)
 
 
 class TestRender:
     # Fully transparent image
     # It's easy to predict it's pixel values
-    trans = TermImage.from_file("tests/images/trans.png")
+    trans = BlockImage.from_file("tests/images/trans.png")
     trans.height = _size
 
     def render_image(self, alpha):

--- a/tests/test_image_iterator.py
+++ b/tests/test_image_iterator.py
@@ -4,15 +4,15 @@ import pytest
 from PIL import Image
 
 from term_image.exceptions import TermImageException
-from term_image.image import ImageIterator, TermImage
+from term_image.image import BlockImage, ImageIterator
 
 _size = (30, 15)
 
-png_image = TermImage(Image.open("tests/images/python.png"))
+png_image = BlockImage(Image.open("tests/images/python.png"))
 gif_img = Image.open("tests/images/lion.gif")
-gif_image = TermImage(gif_img)
+gif_image = BlockImage(gif_img)
 webp_img = Image.open("tests/images/anim.webp")
-webp_image = TermImage(webp_img)
+webp_image = BlockImage(webp_img)
 
 gif_image._size = _size
 webp_image._size = _size
@@ -138,7 +138,7 @@ def test_iter():
             prev_frame = frame
 
     # Frames are the same as for manual iteration
-    gif_image2 = TermImage.from_file(gif_image._source.filename)
+    gif_image2 = BlockImage.from_file(gif_image._source.filename)
     gif_image2._size = _size
     for n, frame in enumerate(ImageIterator(gif_image, 1, "1.1")):
         gif_image2.seek(n)
@@ -164,7 +164,7 @@ def test_caching():
 
     return ""
 
-    gif_image2 = TermImage.from_file(gif_image._source.filename)
+    gif_image2 = BlockImage.from_file(gif_image._source.filename)
     gif_image2._size = _size
     gif_image2._render_image = render
 
@@ -194,7 +194,7 @@ def test_sizing():
             assert next(image_it).count("\n") + 1 == 10
             assert gif_image2._size == (20, 10)
 
-    gif_image2 = TermImage.from_file(gif_image._source.filename)
+    gif_image2 = BlockImage.from_file(gif_image._source.filename)
 
     # Uncached loop
     image_it = ImageIterator(gif_image2, 1, "1.1")
@@ -239,7 +239,7 @@ def test_close():
     assert not hasattr(image_it, "_img")
     assert img.load()
 
-    image_it = ImageIterator(TermImage.from_file(gif_image._source.filename), 1)
+    image_it = ImageIterator(BlockImage.from_file(gif_image._source.filename), 1)
     next(image_it)
     img = image_it._img
     image_it.close()

--- a/tests/test_image_iterator.py
+++ b/tests/test_image_iterator.py
@@ -3,7 +3,7 @@ from types import GeneratorType
 import pytest
 from PIL import Image
 
-from term_image.exceptions import TermImageException
+from term_image.exceptions import TermImageError
 from term_image.image import BlockImage, ImageIterator
 
 _size = (30, 15)
@@ -262,7 +262,7 @@ class TestSeek:
             with pytest.raises(ValueError):
                 image_it.seek(value)
 
-        with pytest.raises(TermImageException):
+        with pytest.raises(TermImageError):
             image_it.seek(1)
 
     def test_seek(self):

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -4,7 +4,7 @@ from random import randint, random
 import pytest
 
 from term_image import FontRatio, get_font_ratio, set_font_ratio
-from term_image.exceptions import TermImageException
+from term_image.exceptions import TermImageError
 from term_image.image import AutoImage, BaseImage, from_file
 
 from . import set_cell_size
@@ -52,7 +52,7 @@ class TestFontRatio:
 
         set_cell_size(None)
         for value in FontRatio:
-            with pytest.raises(TermImageException):
+            with pytest.raises(TermImageError):
                 set_font_ratio(value)
 
     def test_fixed(self):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -4,7 +4,7 @@ import pytest
 from PIL import Image, UnidentifiedImageError
 
 from term_image.exceptions import URLNotFoundError
-from term_image.image import BaseImage, ImageSource, TermImage, from_url
+from term_image.image import BaseImage, BlockImage, ImageSource, from_url
 
 python_image = "tests/images/python.png"
 python_url = (
@@ -16,39 +16,39 @@ python_img = Image.open(python_image)
 
 def test_from_url():
     with pytest.raises(TypeError, match=r".* a string .*"):
-        TermImage.from_url(python_img)
+        BlockImage.from_url(python_img)
     with pytest.raises(ValueError, match="Invalid URL.*"):
-        TermImage.from_url(python_image)
+        BlockImage.from_url(python_image)
     with pytest.raises(URLNotFoundError):
-        TermImage.from_url(python_url + "e")
+        BlockImage.from_url(python_url + "e")
     with pytest.raises(UnidentifiedImageError):
-        TermImage.from_url(
+        BlockImage.from_url(
             "https://raw.githubusercontent.com/AnonymouX47/term-image/main/LICENSE"
         )
 
-    image = TermImage.from_url(python_url)
-    assert isinstance(image, TermImage)
+    image = BlockImage.from_url(python_url)
+    assert isinstance(image, BlockImage)
     assert image._url == python_url
     assert os.path.exists(image._source)
     assert image._source_type is ImageSource.URL
 
     # Ensure size arguments get through
     with pytest.raises(ValueError, match=r".* both width and height"):
-        TermImage.from_url(python_url, width=1, height=1)
+        BlockImage.from_url(python_url, width=1, height=1)
 
     # Ensure scale argument gets through
     with pytest.raises(TypeError, match=r"'scale' .*"):
-        TermImage.from_url(python_url, scale=1.0)
+        BlockImage.from_url(python_url, scale=1.0)
 
 
 def test_source():
-    image = TermImage.from_url(python_url)
+    image = BlockImage.from_url(python_url)
     assert image.source == image._url == python_url
     assert image.source_type is ImageSource.URL
 
 
 def test_close():
-    image = TermImage.from_url(python_url)
+    image = BlockImage.from_url(python_url)
     source = image._source
 
     image.close()


### PR DESCRIPTION
- Renames "term" render style to "block"
- Renames `TermImage` to `BlockImage`.
- Deprecates `TermImage`.
- Changes exception naming scheme to `*Error`.
- Deprecates `TermImageException` and `InvalidSize`.