### PR TITLE
Style-specific API extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] Image category subclasses (of `BaseImage`), `TextImage` and `GraphicsImage` ([#44]).
 - [lib] Automatic font ratio computation ([#45]).
 - [lib] `term_image.FontRatio` enumeration class ([#45]).
+- [lib] Support for style-specific parameters and format specification ([#47]).
+- [lib] Style-specific exception classes ([#47]).
 - [cli] `--style` command-line option for render style selection ([#37]).
 - [cli] `kitty` render style choice for the `--style` CL option ([#39]).
 - [cli] `--force-style` to bypass render style support checks ([#44]).
 - [cli] `--auto-font-ratio` for automatic font ratio determination ([#45]).
+- [cli] Support for style-specific options ([#47]).
 - [tui] Concurrent/Parallel frame rendering for TUI animations ([#42]).
 - [lib,cli,tui] Support for the Kitty terminal graphics protocol ([#39]).
 - [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
@@ -62,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#44]: https://github.com/AnonymouX47/term-image/pull/44
 [#45]: https://github.com/AnonymouX47/term-image/pull/45
 [#46]: https://github.com/AnonymouX47/term-image/pull/46
+[#47]: https://github.com/AnonymouX47/term-image/pull/47
 
 
 ## [0.3.1] - 2022-05-04

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -103,7 +103,7 @@ Image Format Specification
 
 .. code-block:: none
 
-   [h_align] [width] [ . [v_align] [height] ] [ # [threshold | bgcolor] ]
+   [h_align] [width] [ . [v_align] [height] ] [ # [threshold | bgcolor] ] [ + style ]
 
 .. note::
 
@@ -149,5 +149,13 @@ Image Format Specification
 
   * ``bgcolor``: Hex color with which transparent background should be replaced e.g ``ffffff``, ``7faa52``.
   * If neither ``threshold`` nor ``bgcolor`` is present, but ``#`` is present, transparency is disabled (uses the image's default background color, or black if none).
+
+* ``style``: Style-specific format specification.
+
+  See each render style class for its own specification, if it defines.
+
+  ``style`` can be broken down into ``[parent] [current]``, where ``current`` is the
+  spec defined by a class and ``parent`` is the spec defined by a parent of that class.
+  ``parent`` can in turn be **recursively** broken down as such.
 
 See :ref:`Formatted rendering <formatted-render>` for examples.

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1035,6 +1035,8 @@ FOOTNOTES:
         ),
     )
 
+    style_parsers = {}
+
     args = parser.parse_args()
     MAX_DEPTH = args.max_depth
     RECURSIVE = args.recursive
@@ -1129,6 +1131,9 @@ FOOTNOTES:
                     level=_logging.WARNING,
                 )
     log(f"Using {style!r} render style", logger, direct=False)
+
+    style_parser = style_parsers.get(style)
+    style_args = vars(style_parser.parse_known_args()[0]) if style_parser else {}
 
     # Some APCs used for render style support detection get emitted on some
     # non-supporting terminal emulators
@@ -1293,6 +1298,7 @@ FOOTNOTES:
                         and (args.cache_all_anim or args.anim_cache)
                     ),
                     check_size=not args.oversize,
+                    **style_args,
                 )
 
             # Handles `ValueError` and `.exceptions.InvalidSizeError`

--- a/term_image/exceptions.py
+++ b/term_image/exceptions.py
@@ -29,13 +29,41 @@ class InvalidSize(InvalidSizeError):
 # Style-specific exceptions
 
 
+class BaseImageError(TermImageError):
+    """Raised for style-specific errors for subclasses of
+    :py:class:`BaseImage <term_image.image.BaseImage>` defined outside this package.
+    """
+
+
+class GraphicsImageError(TermImageError):
+    """Raised for errors specific to
+    :py:class:`GraphicsImage <term_image.image.GraphicsImage>` and style-specific
+    errors for subclasses defined outside this package.
+    """
+
+
+class TextImageError(TermImageError):
+    """Raised for errors specific to
+    :py:class:`TextImage <term_image.image.TextImage>` and style-specific
+    errors for subclasses defined outside this package.
+    """
+
+
 class BlockImageError(TermImageError):
     """Raised for errors specific to
-    :py:class:`BlockImage <term_image.image.BlockImage>`
+    :py:class:`BlockImage <term_image.image.BlockImage>` and style-specific
+    errors for subclasses defined outside this package.
     """
 
 
 class KittyImageError(TermImageError):
     """Raised for errors specific to
-    :py:class:`KittyImage <term_image.image.KittyImage>`
+    :py:class:`KittyImage <term_image.image.KittyImage>` and style-specific
+    errors for subclasses defined outside this package.
     """
+
+
+def _style_error(cls: type):
+    for cls in cls.__mro__:
+        if cls.__module__.startswith("term_image.image"):
+            return globals()[f"{cls.__name__}Error"]

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -24,8 +24,13 @@ import PIL
 import requests
 from PIL import Image, UnidentifiedImageError
 
-from .. import exceptions, get_font_ratio
-from ..exceptions import InvalidSizeError, TermImageError, URLNotFoundError
+from .. import get_font_ratio
+from ..exceptions import (
+    InvalidSizeError,
+    TermImageError,
+    URLNotFoundError,
+    _style_error,
+)
 from ..utils import ClassInstanceMethod, get_terminal_size, no_redecorate
 
 _ALPHA_THRESHOLD = 40 / 255  # Default alpha threshold
@@ -803,7 +808,7 @@ class BaseImage(ABC):
         If called via:
 
            - a class, sets the class-wide render method.
-           - an instance, sets the instance-specifc render method.
+           - an instance, sets the instance-specific render method.
 
         If *method* is ``None`` and this method is called via:
 
@@ -827,9 +832,7 @@ class BaseImage(ABC):
             cls = (
                 type(self_or_cls) if isinstance(self_or_cls, __class__) else self_or_cls
             )
-            raise getattr(exceptions, f"{cls.__name__}Error")(
-                f"Unknown render method {method!r}"
-            )
+            raise _style_error(cls)(f"Unknown render method {method!r}")
 
         if not method:
             if isinstance(self_or_cls, __class__):

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -1058,7 +1058,7 @@ class BaseImage(ABC):
                 if alpha
                 else _ALPHA_THRESHOLD
             ),
-            style_spec and cls._check_style_format_spec(style_spec) or {},
+            style_spec and cls._check_style_format_spec(style_spec, style_spec) or {},
         )
 
     @staticmethod
@@ -1189,7 +1189,7 @@ class BaseImage(ABC):
         return style_args
 
     @classmethod
-    def _check_style_format_spec(cls, spec: str) -> Dict[str, Any]:
+    def _check_style_format_spec(cls, spec: str, original: str) -> Dict[str, Any]:
         """Validates a style-specific format specification and translates it into
         the required values.
 
@@ -1205,28 +1205,29 @@ class BaseImage(ABC):
         Every overriding method must call the overriden method.
         At every step in the call chain, the specification should be of the form::
 
-            [up] [current] [invalid]
+            [parent] [current] [invalid]
 
         where:
 
         - *current* is the portion to be interpreted at the current level in the chain
-        - *up* is the portion to be interpreted at an higher level in the chain
+        - *parent* is the portion to be interpreted at an higher level in the chain
         - the *invalid* portion determines the validity of the format spec
         - **at least one portion must exist**
 
-        Take care of the portions in the order *invalid*, *up*, *current*, so that
+        Take care of the portions in the order *invalid*, *parent*, *current*, so that
         validity can be determined before processing any part of the format spec.
 
         At any point in the chain where the *invalid* portion exists (i.e is non-empty),
         the format spec can be correctly taken to be invalid.
 
-        An overriding method must call the overridden method with the *up* portion
-        of the given format spec, **if not empty**, such that every successful check
-        ends up at `BaseImage._check_style_args()` or when *up* is empty.
+        An overriding method must call the overridden method with the *parent* portion
+        and the original format spec, **if** *parent* **is not empty**, such that every
+        successful check ends up at `BaseImage._check_style_args()` or when *parent* is
+        empty.
         """
         if spec:
             raise _style_error(cls)(
-                f"Invalid style-specific format specification {spec!r}"
+                f"Invalid style-specific format specification {original!r}"
             )
         return {}
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,7 +6,8 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from term_image import exceptions, set_font_ratio
+from term_image import set_font_ratio
+from term_image.exceptions import TermImageError, _style_error
 from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, TextImage
 from term_image.utils import get_terminal_size
 
@@ -111,7 +112,7 @@ def test_instantiation_Graphics():
         ImageClass._supported = True
         assert isinstance(ImageClass(python_img), GraphicsImage)
         ImageClass._supported = False
-        with pytest.raises(exceptions.TermImageError):
+        with pytest.raises(TermImageError):
             ImageClass(python_img)
     finally:
         ImageClass._supported = original
@@ -140,7 +141,7 @@ def test_set_render_method_All():
 
     default = ImageClass._default_render_method if ImageClass._render_methods else None
 
-    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+    with pytest.raises(_style_error(ImageClass)):
         ImageClass.set_render_method("")
 
     assert ImageClass._render_method == default
@@ -155,7 +156,7 @@ def test_set_render_method_All():
 
     image = ImageClass(python_img)
 
-    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+    with pytest.raises(_style_error(ImageClass)):
         image.set_render_method("")
 
     assert image._render_method == default

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,8 +6,7 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from term_image import set_font_ratio
-from term_image.exceptions import TermImageError, _style_error
+from term_image import exceptions, set_font_ratio
 from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, TextImage
 from term_image.utils import get_terminal_size
 
@@ -112,7 +111,7 @@ def test_instantiation_Graphics():
         ImageClass._supported = True
         assert isinstance(ImageClass(python_img), GraphicsImage)
         ImageClass._supported = False
-        with pytest.raises(TermImageError):
+        with pytest.raises(exceptions.TermImageError):
             ImageClass(python_img)
     finally:
         ImageClass._supported = original
@@ -141,7 +140,7 @@ def test_set_render_method_All():
 
     default = ImageClass._default_render_method if ImageClass._render_methods else None
 
-    with pytest.raises(_style_error(ImageClass)):
+    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
         ImageClass.set_render_method("")
 
     assert ImageClass._render_method == default
@@ -156,7 +155,7 @@ def test_set_render_method_All():
 
     image = ImageClass(python_img)
 
-    with pytest.raises(_style_error(ImageClass)):
+    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
         image.set_render_method("")
 
     assert image._render_method == default

--- a/tests/common.py
+++ b/tests/common.py
@@ -332,4 +332,17 @@ class TestFontRatio_Graphics:
             set_font_ratio(0.5)
 
 
+def test_style_args_All():
+    image = ImageClass(python_img)
+    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+        image.draw(_=None)
+
+
+def test_style_format_spec_All():
+    image = ImageClass(python_img)
+    for spec in ("+\t", "20+\r", ".^+\a", "#+\0"):
+        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+            format(image, spec)
+
+
 __all__ = [name for name in globals() if name.startswith(("test_", "Test"))]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -506,7 +506,7 @@ class TestFormatting:
     image = BlockImage(python_img)
     image.scale = 0.5  # To ensure there's padding
     render = str(image)
-    check_formatting = image._check_formatting
+    check_formatting = staticmethod(image._check_formatting)
     format_render = image._format_render
 
     def test_args(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -722,6 +722,11 @@ class TestFormatting:
             "#fffffff",
             "#a45gh4",
             " ",
+            # style-specific section
+            "+",
+            "20+",
+            ".^+",
+            "#+",
         ):
             with pytest.raises(ValueError, match=r"Invalid format specification"):
                 self.image._check_format_spec(spec)


### PR DESCRIPTION
- Improves style-specific error handling:
  - Fixes handling of style-specific errors for subclasses defined outside the package.
  - Adds `BaseImageError`, `GraphicsImageError`, `TextImageError` in `.exceptions`.
  - Adds `.exceptions._style_error()` for selection of style-specific exceptions.
- Implements support for style-specific parameters.
  - Adds `_style_args` and `_check_style_args()` to `BaseImage`.
- Implements support for style-specific format specification.
  - Adds `BasImage._check_syle_format_spec()`.