### PR TITLE
Kitty z-index feature

### DIFF
--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1052,6 +1052,8 @@ FOOTNOTES:
     style_parsers = {"kitty": kitty_parser}
 
     for style_parser in style_parsers.values():
+        parser._actions.extend(style_parser._actions)
+        parser._option_string_actions.update(style_parser._option_string_actions)
         parser._action_groups.extend(style_parser._action_groups)
         parser._mutually_exclusive_groups.extend(
             style_parser._mutually_exclusive_groups

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1041,6 +1041,7 @@ FOOTNOTES:
         "These options apply only when the 'kitty' render style is used",
     )
     kitty_options.add_argument(
+        "--kz",
         "--kitty-z-index",
         metavar="N",
         dest="z_index",

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1127,8 +1127,8 @@ FOOTNOTES:
     ImageClass = {"auto": None, "kitty": KittyImage, "block": BlockImage}[args.style]
     if not ImageClass:
         ImageClass = _best_style()
+    args.style = ImageClass.__name__[:-5].lower()
 
-    style = ImageClass.__name__[:-5].lower()
     if args.force_style:
         ImageClass._supported = True
     else:
@@ -1136,7 +1136,7 @@ FOOTNOTES:
             ImageClass(None)
         except TermImageError:  # Instantiation isn't permitted
             log(
-                f"The {style!r} render style is not supported in the current "
+                f"The {args.style!r} render style is not supported in the current "
                 "terminal! To use it anyways, add '--force-style'.",
                 logger,
                 level=_logging.CRITICAL,
@@ -1145,14 +1145,14 @@ FOOTNOTES:
         except TypeError:  # Instantiation is permitted
             if not ImageClass.is_supported():
                 log(
-                    f"The {style!r} render style might not be fully supported in "
+                    f"The {args.style!r} render style might not be fully supported in "
                     "the current terminal... using it anyways.",
                     logger,
                     level=_logging.WARNING,
                 )
-    log(f"Using {style!r} render style", logger, direct=False)
+    log(f"Using {args.style!r} render style", logger, direct=False)
 
-    style_parser = style_parsers.get(style)
+    style_parser = style_parsers.get(args.style)
     style_args = vars(style_parser.parse_known_args()[0]) if style_parser else {}
 
     # Some APCs used for render style support detection get emitted on some

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -984,7 +984,7 @@ FOOTNOTES:
     # Logging
     log_options_ = parser.add_argument_group(
         "Logging Options",
-        "NOTE: These are mutually exclusive",
+        "NOTE: All these, except '-l/--log-file', are mutually exclusive",
     )
     log_options = log_options_.add_mutually_exclusive_group()
 
@@ -1035,7 +1035,27 @@ FOOTNOTES:
         ),
     )
 
-    style_parsers = {}
+    kitty_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
+    kitty_options = kitty_parser.add_argument_group(
+        "Kitty Style Options",
+        "These options apply only when the 'kitty' render style is used",
+    )
+    kitty_options.add_argument(
+        "--kitty-z-index",
+        metavar="N",
+        dest="z_index",
+        default=0,
+        type=int,
+        help="Image/Text stacking order",
+    )
+
+    style_parsers = {"kitty": kitty_parser}
+
+    for style_parser in style_parsers.values():
+        parser._action_groups.extend(style_parser._action_groups)
+        parser._mutually_exclusive_groups.extend(
+            style_parser._mutually_exclusive_groups
+        )
 
     args = parser.parse_args()
     MAX_DEPTH = args.max_depth

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -81,6 +81,49 @@ class KittyImage(GraphicsImage):
         )
     }
 
+    # Only defined for the purpose of proper self-documentation
+    def draw(self, *args, z_index: Optional[int] = 0, **kwargs) -> None:
+        """Draws an image to standard output.
+
+        Extends the common interface with style-specific parameters.
+
+        Args:
+            args: Positional arguments passed up the inheritance chain.
+            z_index: The stacking order of images and text.
+
+              Images drawn in the same location with different z-index values will be
+              blended if they are semi-transparent. If *z_index* is:
+
+              * ``>= 0``, the image will be drawn above text.
+              * ``< 0``, the image will be drawn below text.
+              * ``< -(2 ** 31) / 2``, the image will be drawn below non-default text
+                background colors.
+              * ``None``, deletes any directly overlapping image.
+
+              .. note::
+                Currently, ``None`` is **only used internally** as it's buggy on
+                Kitty <= 0.25.0. It's only mentioned here for the sake of completeness.
+
+                Also, inter-mixing text with an image requires writing the text after
+                drawing the image, as any text within the region covered by the image is
+                overwritten when the image is drawn.
+
+            kwargs: Keyword arguments passed up the inheritance chain.
+
+        See the ``draw()`` method of the parent classes for full details, including the
+        description of other parameters.
+        """
+        arguments = locals()
+        super().draw(
+            *args,
+            **kwargs,
+            **{
+                var: arguments[var]
+                for var, default in __class__.draw.__kwdefaults__.items()
+                if arguments[var] != default
+            },
+        )
+
     @classmethod
     @lock_tty
     def is_supported(cls):

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -236,6 +236,25 @@ class KittyImage(GraphicsImage):
         return tuple(map(mul, self.rendered_size, get_cell_size() or (1, 2)))
 
     @staticmethod
+    def _handle_interrupted_draw():
+        """Performs neccessary actions when image drawing is interrupted.
+
+        If drawing is interruped while transmiting a command, it causes terminal to
+        wait for more data (in fact, it actually consumes any output following)
+        until the output reaches the expected payload size or ST (String Terminator)
+        is written.
+
+        Also, if the image data was chunked, it would be expecting the last chunk.
+        In this case, output is not consumed but the next graphics command sent
+        might not be treated as expected on some terminals e.g Konsole.
+        """
+
+        # End last command (does no harm if there wasn't an unterminated commanand)
+        # and send "last chunk" in case the last transmission was chunked.
+        # Konsole sometimes requires ST to be written twice.
+        print(f"{_END * 2}{_START}q=1,m=0;{_END}", end="", flush=True)
+
+    @staticmethod
     def _pixels_cols(
         *, pixels: Optional[int] = None, cols: Optional[int] = None
     ) -> int:

--- a/term_image/tui/__init__.py
+++ b/term_image/tui/__init__.py
@@ -60,6 +60,10 @@ def init(
     Image._ti_alpha = (
         "#" if args.no_alpha else "#" + (args.alpha_bg or f"{args.alpha:f}"[1:])
     )
+    # KONSOLE does NOT blend images with the same z-index, hence is better off without
+    # `z_index=None`
+    if args.style == "kitty" and ImageClass._KONSOLE_VERSION:
+        del render.style_specs["kitty"]
     Image._ti_style_spec = render.style_specs.get(args.style, "")
 
     # daemon, to avoid having to check if the main process has been interrupted

--- a/term_image/tui/__init__.py
+++ b/term_image/tui/__init__.py
@@ -57,6 +57,11 @@ def init(
     )
     main.displayer = main.display_images(".", images, contents, top_level=True)
 
+    Image._ti_alpha = (
+        "#" if args.no_alpha else "#" + (args.alpha_bg or f"{args.alpha:f}"[1:])
+    )
+    Image._ti_style_spec = render.style_specs.get(args.style, "")
+
     # daemon, to avoid having to check if the main process has been interrupted
     menu_scanner = logging.Thread(target=scan_dir_menu, name="MenuScanner", daemon=True)
     grid_scanner = logging.Thread(target=scan_dir_grid, name="GridScanner", daemon=True)
@@ -82,10 +87,6 @@ def init(
     )
     main.loop.screen.clear()
     main.loop.screen.set_terminal_properties(2**24)
-
-    Image._ti_alpha = (
-        "#" if args.no_alpha else "#" + (args.alpha_bg or f"{args.alpha:f}"[1:])
-    )
 
     logger = _logging.getLogger(__name__)
     logging.log("Launching TUI", logger, direct=False)

--- a/term_image/tui/keys.py
+++ b/term_image/tui/keys.py
@@ -656,10 +656,6 @@ def switch_pane():
             main.set_context("image-grid")
             set_image_grid_actions()
 
-    # Too glitchy for the grid
-    if main.get_context() == "image" or main.get_prev_context() == "image":
-        main.ImageClass._clear_images() and ImageCanvas.change()
-
 
 # confirmation
 @register_key(("confirmation", "Confirm"))

--- a/term_image/tui/render.py
+++ b/term_image/tui/render.py
@@ -435,7 +435,7 @@ logger = _logging.getLogger(__name__)
 anim_render_queue = Queue()
 grid_render_queue = Queue()
 image_render_queue = Queue()
-style_specs = {}
+style_specs = {"kitty": "+z"}
 
 # Set from `.tui.init()`
 # # Corresponsing to command-line args

--- a/term_image/tui/render.py
+++ b/term_image/tui/render.py
@@ -9,7 +9,7 @@ from queue import Empty, Queue
 from threading import Event
 from typing import Optional, Union
 
-from .. import logging, notify
+from .. import cli, logging, notify
 from ..logging_multi import Process
 
 
@@ -64,6 +64,7 @@ def manage_anim_renders() -> bool:
             frame_render_out,
             ready,
             ImageClass,
+            style_specs.get(cli.args.style, ""),
             REPEAT,
             ANIM_CACHED,
         ),
@@ -125,7 +126,12 @@ def manage_image_renders():
     image_render_out = (mp_Queue if multi else Queue)()
     renderer = (Process if multi else logging.Thread)(
         target=render_images,
-        args=(image_render_in, image_render_out, ImageClass),
+        args=(
+            image_render_in,
+            image_render_out,
+            ImageClass,
+            style_specs.get(cli.args.style, ""),
+        ),
         kwargs=dict(multi=multi, out_extras=False, log_faults=True),
         name="ImageRenderer",
         redirect_notifs=True,
@@ -201,7 +207,12 @@ def manage_grid_renders(n_renderers: int):
     renderers = [
         (Process if multi else logging.Thread)(
             target=render_images,
-            args=(grid_render_in, grid_render_out, ImageClass),
+            args=(
+                grid_render_in,
+                grid_render_out,
+                ImageClass,
+                style_specs.get(cli.args.style, ""),
+            ),
             kwargs=dict(multi=multi, out_extras=True, log_faults=False),
             name="GridRenderer" + f"-{n}" * multi,
         )
@@ -293,6 +304,7 @@ def render_frames(
     output: Union[Queue, mp_Queue],
     ready: Union[Event, mp_Event],
     ImageClass: type,
+    style_spec: str,
     repeat: int,
     cached: Union[bool, int],
 ):
@@ -335,7 +347,9 @@ def render_frames(
                 block = True
             elif isinstance(data, tuple):
                 new_repeat, frame_no = data
-                animator = ImageIterator(image, new_repeat, f"1.1{alpha}", cached)
+                animator = ImageIterator(
+                    image, new_repeat, f"1.1{alpha}{style_spec}", cached
+                )
                 next(animator)
                 animator.seek(frame_no)
                 image.set_size(maxsize=size)
@@ -345,7 +359,9 @@ def render_frames(
                 # in MainProcess::MainThread is always correct, since frames should be
                 # rendered ahead.
                 image = ImageClass.from_file(data)
-                animator = ImageIterator(image, repeat, f"1.1{alpha}", cached)
+                animator = ImageIterator(
+                    image, repeat, f"1.1{alpha}{style_spec}", cached
+                )
                 image.set_size(maxsize=size)
                 block = False
 
@@ -356,6 +372,7 @@ def render_images(
     input: Union[Queue, mp_Queue],
     output: Union[Queue, mp_Queue],
     ImageClass: type,
+    style_spec: str,
     *,
     multi: bool,
     out_extras: bool,
@@ -389,9 +406,14 @@ def render_images(
         # **as needed**. Trimmed padding lines are never generated at all.
         try:
             output.put(
-                (image._source, f"{image:1.1{alpha}}", size, image.rendered_size)
+                (
+                    image._source,
+                    f"{image:1.1{alpha}{style_spec}}",
+                    size,
+                    image.rendered_size,
+                )
                 if out_extras
-                else f"{image:1.1{alpha}}"
+                else f"{image:1.1{alpha}{style_spec}}"
             )
         except Exception as e:
             output.put(
@@ -413,6 +435,7 @@ logger = _logging.getLogger(__name__)
 anim_render_queue = Queue()
 grid_render_queue = Queue()
 image_render_queue = Queue()
+style_specs = {}
 
 # Set from `.tui.init()`
 # # Corresponsing to command-line args

--- a/term_image/tui/widgets.py
+++ b/term_image/tui/widgets.py
@@ -241,7 +241,9 @@ class Image(urwid.Widget):
 
     _ti_grid_cache = {}
 
-    _ti_alpha = f"{_ALPHA_THRESHOLD}"[1:]  # Updated from `.tui.init()`
+    # Updated from `.tui.init()`
+    _ti_alpha = f"{_ALPHA_THRESHOLD}"[1:]
+    _ti_style_spec = ""
 
     def __init__(self, image: BaseImage):
         self._ti_image = image
@@ -334,7 +336,9 @@ class Image(urwid.Widget):
             # When the grid render cell width adjusts; when _maxcols_ < _cell_width_
             try:
                 canv = ImageCanvas(
-                    f"{image:1.1{self._ti_alpha}}".encode().split(b"\n"),
+                    f"{image:1.1{self._ti_alpha}{self._ti_style_spec}}".encode().split(
+                        b"\n"
+                    ),
                     size,
                     image.rendered_size,
                 )

--- a/term_image/tui/widgets.py
+++ b/term_image/tui/widgets.py
@@ -353,7 +353,6 @@ class Image(urwid.Widget):
                 tui_main.ImageClass._clear_images()
             elif frame_no != self._ti_frame_no:
                 self._ti_frame_no = frame_no
-                tui_main.ImageClass._clear_images() and ImageCanvas.change()
         elif self._ti_canv and self._ti_canv.size == size:
             canv = self._ti_canv
         else:
@@ -368,7 +367,6 @@ class Image(urwid.Widget):
             elif (self, size, self._ti_alpha) != __class__._ti_rendering_image_info:
                 image_render_queue.put((self, size, self._ti_alpha))
             canv = __class__._ti_placeholder.render(size)
-            tui_main.ImageClass._clear_images()
 
         return canv
 


### PR DESCRIPTION
Resolving #40

- Implements usage of kitty graphics protocol z-index feature.
  - Adds `z_index` style-specific parameter for "kitty" render style.
  - Adds `mix` style-specific parameter for "kitty" render style.
- Adds "kitty" style-specific format specification.
  - Adds z-index spec.
  - Adds image/text inter-mix policy spec.
- Improves "kitty" style support detection and identification of supported terminals.
- Adds kitty style-specific CLI options.
- Implements workarounds for animation in supported terminal emulators.
- Implements workarounds for redrawing images in the TUI for different supported terminal emulators.
- Fixes output deadlock and messed up terminal state when image drawing is interrupted mid-transmission.
- Fixes parsing of style-specific CLI options.