### PR TITLE
iTerm2 inline image protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [lib] `term_image.FontRatio` enumeration class ([#45]).
 - [lib] Support for style-specific parameters and format specification ([#47]).
 - [lib] Style-specific exception classes ([#47]).
+- [lib] `ITerm2Image` class, `iterm2` render style; Support for the iTerm2 inline image protocol ([#50]).
+- [lib] `term_image.TermImageWarning`; pacage specific warning category ([#50]).
 - [cli] `--style` command-line option for render style selection ([#37]).
-- [cli] `kitty` render style choice for the `--style` CL option ([#39]).
+- [cli] `kitty` render style choice for the `--style` command-line option ([#39]).
 - [cli] `--force-style` to bypass render style support checks ([#44]).
 - [cli] `--auto-font-ratio` for automatic font ratio determination ([#45]).
 - [cli] Support for style-specific options ([#47]).
+- [cli] `iterm2` render style choice for the `--style` command-line option ([#50]).
+- [cli] `--itn/--iterm2-native` and `--itn-max/--iterm2-native-maxsize` style-specific CL options for 'iterm2' native animation ([#50]).
 - [tui] Concurrent/Parallel frame rendering for TUI animations ([#42]).
 - [lib,cli,tui] Support for the Kitty terminal graphics protocol ([#39]).
 - [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
@@ -66,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#45]: https://github.com/AnonymouX47/term-image/pull/45
 [#46]: https://github.com/AnonymouX47/term-image/pull/46
 [#47]: https://github.com/AnonymouX47/term-image/pull/47
+[#50]: https://github.com/AnonymouX47/term-image/pull/50
 
 
 ## [0.3.1] - 2022-05-04

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -49,6 +49,10 @@ Core Library Definitions
       :members:
       :show-inheritance:
 
+   .. autoclass:: ITerm2Image
+      :members:
+      :show-inheritance:
+
    .. autoclass:: KittyImage
       :members:
       :show-inheritance:

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -49,7 +49,7 @@ Represent images using ASCII or Unicode symbols, and in some cases, in conjuncti
 
 Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
 
-- :py:class:`BlockImage <term_image.image.BlockImage>`.
+* :py:class:`BlockImage <term_image.image.BlockImage>`
 
 Graphics-based Render Styles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,8 @@ Represent images with actual pixels, using terminal graphics protocols.
 
 Classes for render styles in this category are subclasses of :py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
 
-- :py:class:`KittyImage <term_image.image.KittyImage>`.
+* :py:class:`KittyImage <term_image.image.KittyImage>`
+* :py:class:`ITerm2Image <term_image.image.ITerm2Image>`
 
 
 .. _auto-font-ratio:

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -12,6 +12,10 @@ Reference
 Top-Level Definitions
 ---------------------
 
+.. autofunction:: term_image.set_font_ratio
+
+.. autofunction:: term_image.get_font_ratio
+
 .. autoclass:: term_image.FontRatio
    :show-inheritance:
 
@@ -21,9 +25,8 @@ Top-Level Definitions
    .. autoattribute:: FULL_AUTO
       :annotation:
 
-.. autofunction:: term_image.set_font_ratio
-
-.. autofunction:: term_image.get_font_ratio
+.. autoclass:: term_image.TermImageWarning
+   :show-inheritance:
 
 |
 

--- a/term_image/__init__.py
+++ b/term_image/__init__.py
@@ -1,13 +1,14 @@
 """
 term-image
 
-Display images in a terminal
+Display images in the terminal
 
 Provides
 ========
-    1. A library with utilities to display images in a terminal in various ways.
-    2. A CLI to display individual images from a local filesystem or URLs.
-    3. A TUI to browse multiple images on a local filesystem or from URLS.
+    1. A library with features to display images in a terminal in various ways.
+    2. A CLI to display images from a local filesystem or URLs.
+    3. A TUI to browse through images and directories on a local filesystem
+       or from URLS.
 
 It basically works by converting images into text, since that's all conventional
 terminals can represent.
@@ -19,7 +20,7 @@ Copyright (c) 2022
 
 from __future__ import annotations
 
-__all__ = ("FontRatio", "set_font_ratio", "get_font_ratio")
+__all__ = ("set_font_ratio", "get_font_ratio", "FontRatio", "TermImageWarning")
 __author__ = "AnonymouX47"
 
 from enum import Enum, auto
@@ -107,6 +108,10 @@ class FontRatio(Enum):
 
     AUTO = auto()
     FULL_AUTO = auto()
+
+
+class TermImageWarning(UserWarning):
+    """Package-specific warning category"""
 
 
 _font_ratio = 0.5

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -587,15 +587,15 @@ Render Styles:
         - Konsole >= 22.04.0
     iterm2: Uses the iTerm2 inline image protocol. Currently supported terminal
         emulators include (but might not be limited to):
-        - `iTerm2
-        - `Konsole >= 22.04.0
-        - `WezTerm
+        - iTerm2
+        - Konsole >= 22.04.0
+        - WezTerm
     block: Uses unicode half blocks with 24-bit color escape codes to represent images
         with a density of two pixels per character cell.
 
-    Using a terminal-graphics-based style not supported by the active terminal is not
-    allowed by default.
-    To force a style that is normally unsupported, add the '--force-style' flag.
+    Using a terminal graphics-based style not supported by the active terminal is not
+    allowed by default. To force a style that is normally unsupported, add the
+    '--force-style' flag.
 
 FOOTNOTES:
   1. Width and height are in units of columns and lines repectively.
@@ -1065,7 +1065,7 @@ FOOTNOTES:
         dest="z_index",
         default=0,
         type=int,
-        help="Image stacking order",
+        help="Image stacking order (default: 0)",
     )
 
     iterm2_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
@@ -1356,13 +1356,15 @@ FOOTNOTES:
                     image.frame_duration = args.frame_duration
 
                 if args.style == "iterm2":
-                    if ImageClass._TERM == "konsole":
-                        image.set_render_method("whole")
-                    # Always applies to non-native animations also
-                    elif image.rendered_height <= get_terminal_size()[1]:
-                        image.set_render_method("whole")
-                    else:
-                        image.set_render_method("lines")
+                    image.set_render_method(
+                        "whole"
+                        if (
+                            ImageClass._TERM == "konsole"
+                            # Always applies to non-native animations also
+                            or image.rendered_height <= get_terminal_size()[1]
+                        )
+                        else "lines"
+                    )
 
                 image.draw(
                     *(

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -20,14 +20,14 @@ import requests
 
 from . import FontRatio, __version__, config, logging, notify, set_font_ratio, tui
 from .config import config_options, store_config
-from .exceptions import TermImageError, URLNotFoundError
+from .exceptions import TermImageError, URLNotFoundError, _style_error
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
 from .image import BlockImage, ITerm2Image, KittyImage, _best_style
 from .image.common import _ALPHA_THRESHOLD
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
 from .tui.widgets import Image
-from .utils import OS_IS_UNIX, write_tty
+from .utils import OS_IS_UNIX, get_terminal_size, write_tty
 
 
 def check_dir(
@@ -593,8 +593,9 @@ FOOTNOTES:
   2. The size is multiplied by the scale on each axis respectively before the image
      is rendered. A scale value must be such that 0.0 < value <= 1.0.
   3. In CLI mode, only image sources are used, directory sources are skipped.
-     Animated images are displayed only when animation is disabled (with `--no-anim`)
-     or when there's only one image source.
+     Animated images are displayed only when animation is disabled (with `--no-anim`),
+     when there's only one image source or when using native animation of some render
+     styles.
   4. Any image having more pixels than the specified maximum will be:
      - skipped, in CLI mode, if '--max-pixels-cli' is specified.
      - replaced, in TUI mode, with a placeholder when displayed but can still be forced
@@ -1042,7 +1043,7 @@ FOOTNOTES:
 
     kitty_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
     kitty_options = kitty_parser.add_argument_group(
-        "Kitty Style Options",
+        "Kitty Style Options (CLI-only)",
         "These options apply only when the 'kitty' render style is used",
     )
     kitty_options.add_argument(
@@ -1052,11 +1053,23 @@ FOOTNOTES:
         dest="z_index",
         default=0,
         type=int,
-        help="Image/Text stacking order",
+        help="Image stacking order",
     )
 
-    style_parsers = {"kitty": kitty_parser}
+    iterm2_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
+    iterm2_options = iterm2_parser.add_argument_group(
+        "iTerm2 Style Options (CLI-only)",
+        "These options apply only when the 'iterm2' render style is used",
+    )
+    iterm2_options.add_argument(
+        "--itn",
+        "--iterm2-native",
+        action="store_true",
+        dest="native",
+        help="Use iTerm2's native animation (Animations will not be skipped)",
+    )
 
+    style_parsers = {"kitty": kitty_parser, "iterm2": iterm2_parser}
     for style_parser in style_parsers.values():
         parser._actions.extend(style_parser._actions)
         parser._option_string_actions.update(style_parser._option_string_actions)
@@ -1275,6 +1288,10 @@ FOOTNOTES:
     ):
         log("Running in CLI mode", logger, direct=False)
 
+        style_error = _style_error(ImageClass)
+        if style_args.get("native") and len(images) > 1:
+            style_args["stall_native"] = False
+
         show_name = len(args.sources) > 1
         for entry in images:
             image = entry[1]._ti_image
@@ -1287,7 +1304,12 @@ FOOTNOTES:
                 )
                 continue
 
-            if not args.no_anim and image._is_animated and len(images) > 1:
+            if (
+                not args.no_anim
+                and image._is_animated
+                and not style_args.get("native")
+                and len(images) > 1
+            ):
                 log(f"Skipping animated image: {entry[0]!r}", logger, verbose=True)
                 continue
 
@@ -1306,6 +1328,15 @@ FOOTNOTES:
                 )
                 if args.frame_duration:
                     image.frame_duration = args.frame_duration
+
+                if args.style == "iterm2":
+                    if ImageClass._TERM == "konsole":
+                        image.set_render_method("whole")
+                    # Always applies to non-native animations also
+                    elif image.rendered_height <= get_terminal_size()[1]:
+                        image.set_render_method("whole")
+                    else:
+                        image.set_render_method("lines")
 
                 image.draw(
                     *(
@@ -1337,7 +1368,7 @@ FOOTNOTES:
             # Handles `ValueError` and `.exceptions.InvalidSizeError`
             # raised by `BaseImage.set_size()`, scaling value checks
             # or padding width/height checks.
-            except ValueError as e:
+            except (ValueError, style_error) as e:
                 notify.notify(str(e), level=notify.ERROR)
     elif OS_IS_UNIX:
         notify.end_loading()

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -22,7 +22,7 @@ from . import FontRatio, __version__, config, logging, notify, set_font_ratio, t
 from .config import config_options, store_config
 from .exceptions import TermImageError, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
-from .image import BlockImage, KittyImage, _best_style
+from .image import BlockImage, ITerm2Image, KittyImage, _best_style
 from .image.common import _ALPHA_THRESHOLD
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
@@ -573,6 +573,11 @@ Render Styles:
         include (but might not be limited to):
         - Kitty >= 0.20.0
         - Konsole >= 22.04.0
+    iterm2: Uses the iTerm2 inline image protocol. Currently supported terminal
+        emulators include (but might not be limited to):
+        - `iTerm2
+        - `Konsole >= 22.04.0
+        - `WezTerm
     block: Uses unicode half blocks with 24-bit color escape codes to represent images
         with a density of two pixels per character cell.
 
@@ -630,7 +635,7 @@ FOOTNOTES:
     general.add_argument(
         "-S",
         "--style",
-        choices=("auto", "kitty", "block"),
+        choices=("auto", "kitty", "iterm2", "block"),
         default="auto",
         help='Image render style (default: auto). See "Render Styles" below',
     )
@@ -1104,7 +1109,12 @@ FOOTNOTES:
         )
         args.font_ratio = 0.5
 
-    ImageClass = {"auto": None, "kitty": KittyImage, "block": BlockImage}[args.style]
+    ImageClass = {
+        "auto": None,
+        "kitty": KittyImage,
+        "iterm2": ITerm2Image,
+        "block": BlockImage,
+    }[args.style]
     if not ImageClass:
         ImageClass = _best_style()
 

--- a/term_image/exceptions.py
+++ b/term_image/exceptions.py
@@ -56,6 +56,13 @@ class BlockImageError(TermImageError):
     """
 
 
+class ITerm2ImageError(TermImageError):
+    """Raised for errors specific to
+    :py:class:`ITerm2Image <term_image.image.ITerm2Image>` and style-specific
+    errors for subclasses defined outside this package.
+    """
+
+
 class KittyImageError(TermImageError):
     """Raised for errors specific to
     :py:class:`KittyImage <term_image.image.KittyImage>` and style-specific

--- a/term_image/image/__init__.py
+++ b/term_image/image/__init__.py
@@ -13,6 +13,7 @@ __all__ = (
     "GraphicsImage",
     "TextImage",
     "BlockImage",
+    "ITerm2Image",
     "KittyImage",
     "TermImage",
     "ImageIterator",
@@ -30,6 +31,7 @@ from .common import (  # noqa:F401
     ImageSource,
     TextImage,
 )
+from .iterm2 import ITerm2Image  # noqa:F401
 from .kitty import KittyImage  # noqa:F401
 
 
@@ -86,4 +88,4 @@ def _best_style():
 
 
 # In order of preference
-_styles = (KittyImage, BlockImage)
+_styles = (KittyImage, ITerm2Image, BlockImage)

--- a/term_image/image/common.py
+++ b/term_image/image/common.py
@@ -500,7 +500,7 @@ class BaseImage(ABC):
         pad_width: Optional[int] = None,
         v_align: Optional[str] = None,
         pad_height: Optional[int] = None,
-        alpha: Optional[float] = _ALPHA_THRESHOLD,
+        alpha: Optional[float, str] = _ALPHA_THRESHOLD,
         *,
         scroll: bool = False,
         animate: bool = True,
@@ -587,9 +587,10 @@ class BaseImage(ABC):
 
           * *scroll* is ignored.
           * Image size and :term:`padding height` are always validated, if set or given.
+          * **with the exception of native animations provided by some render styles**.
 
         * Animations, **by default**, are infinitely looped and can be terminated
-          with ``Ctrl-C`` (``SIGINT``), raising ``KeyboardInterrupt``.
+          with **Ctrl+C** (``SIGINT``), raising ``KeyboardInterrupt``.
         """
         fmt = self._check_formatting(h_align, pad_width, v_align, pad_height)
 
@@ -615,7 +616,8 @@ class BaseImage(ABC):
             )
 
         if (
-            self._is_animated
+            not style.get("native")
+            and self._is_animated
             and animate
             and None is not pad_height > get_terminal_size()[1]
         ):
@@ -660,7 +662,7 @@ class BaseImage(ABC):
             render,
             scroll=scroll,
             check_size=check_size,
-            animated=self._is_animated and animate,
+            animated=not style.get("native") and self._is_animated and animate,
         )
 
     @classmethod

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import io
 import re
+from base64 import standard_b64encode
+from typing import Set, Union
+
+import PIL
 
 from ..utils import lock_tty, query_terminal, read_tty
 from .common import GraphicsImage
+
+# Constants for render methods
+LINES = "lines"
+WHOLE = "whole"
 
 
 class ITerm2Image(GraphicsImage):
@@ -11,13 +20,46 @@ class ITerm2Image(GraphicsImage):
 
     See :py:class:`GraphicsImage` for the complete description of the constructor.
 
+    **Render Methods:**
+
+    :py:class:`KittyImage` provides two methods of :term:`rendering` images, namely:
+
+    lines
+       Renders an image line-by-line i.e the image if evenly split up across
+       the number of line it should occupy and all portions is joined together by
+       ``\\n`` (newline sequence) to give the whole image.
+
+       Pros:
+
+         * Good for use cases where it might be required to trim some lines of the
+           image.
+
+    whole
+       Renders an image all at once i.e the entire image data is encoded into the first
+       line of the :term:`rendered` output, such that the entire image is drawn once
+       by the terminal and still occupies the proper amount of lines and columns.
+
+       Pros:
+
+         * Renders faster and results are more compact (i.e less in character count)
+           compared to the ``lines`` method since the entire image is encoded at once.
+         * Better for images that are large in resolution and pixel density.
+
+    The render method can be set with
+    :py:meth:`set_render_method() <BaseImage.set_render_method>` using the names
+    specified above.
+
     ATTENTION:
         Currently supported terminal emulators include:
 
-          * `ITerm2 <https://iterm2.com>`_.
+          * `iTerm2 <https://iterm2.com>`_.
           * `Konsole <https://konsole.kde.org>`_ >= 22.04.0.
           * `WezTerm <https://wezfurlong.org/wezterm/>`_.
     """
+
+    _render_methods: Set[str] = {LINES, WHOLE}
+    _default_render_method: str = LINES
+    _render_method: str = LINES
 
     _TERM: str = ""
     _TERM_VERSION: str = ""
@@ -57,3 +99,87 @@ class ITerm2Image(GraphicsImage):
                 cls._supported = False
 
         return cls._supported
+
+    def _render_image(
+        self, img: PIL.Image.Image, alpha: Union[None, float, str]
+    ) -> str:
+        # Using `width=<columns>`, `height=<lines>` and `preserveAspectRatio=0` ensures
+        # that an image always occupies the correct amount of columns and lines even if
+        # the cell size has changed when it's drawn.
+        # Since we use `width` and `height` control data keys, there's no need
+        # upscaling an image on this end; ensures minimal payload.
+
+        r_width, r_height = self.rendered_size
+        width, height = self._get_minimal_render_size()
+
+        img = self._get_render_data(img, alpha, size=(width, height), pixel_data=False)[
+            0
+        ]
+        format = "jpeg" if img.mode == "RGB" else "png"
+        if self._render_method == LINES:
+            raw_image = io.BytesIO(img.tobytes())
+            compressed_image = io.BytesIO()
+        else:
+            compressed_image = io.BytesIO()
+            img.save(compressed_image, format)
+
+        # clean up
+        if img is not self._source:
+            img.close()
+
+        # Workarounds
+        is_on_konsole = self._TERM == "konsole"
+        jump_right = f"\033[{r_width}C"
+
+        if self._render_method == LINES:
+            # NOTE: It's more efficient to write separate strings to the buffer
+            # separately than concatenate and write together.
+
+            cell_height = height // r_height
+            bytes_per_line = width * cell_height * (len(img.mode))
+            control_data = (
+                f";width={r_width};height=1;preserveAspectRatio=0;inline=1"
+                f"{';doNotMoveCursor=1' * is_on_konsole}:"
+            )
+
+            with io.StringIO() as buffer, raw_image, compressed_image:
+                for line in range(1, r_height + 1):
+                    compressed_image.seek(0)
+                    compressed_image.truncate()
+                    with PIL.Image.frombytes(
+                        img.mode, (width, cell_height), raw_image.read(bytes_per_line)
+                    ) as img:
+                        img.save(compressed_image, format)
+
+                    buffer.write(f"\033]1337;File=size={compressed_image.tell()}")
+                    buffer.write(control_data)
+                    buffer.write(
+                        standard_b64encode(compressed_image.getvalue()).decode()
+                    )
+                    buffer.write(ST)
+                    is_on_konsole and buffer.write(jump_right)
+                    line < r_height and buffer.write("\n")
+
+                return buffer.getvalue()
+        else:
+            with compressed_image:
+                control_data = "".join(
+                    (
+                        f"size={compressed_image.tell()};width={r_width}"
+                        f";height={r_height};preserveAspectRatio=0;inline=1"
+                        f"{';doNotMoveCursor=1' * is_on_konsole}:"
+                    )
+                )
+                return "".join(
+                    (
+                        "\033]1337;File=",
+                        control_data,
+                        standard_b64encode(compressed_image.getvalue()).decode(),
+                        ST,
+                        f"{jump_right}\n" * (r_height - 1) if is_on_konsole else "",
+                        jump_right * is_on_konsole,
+                    )
+                )
+
+
+ST = "\033\\"

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -25,11 +25,11 @@ class ITerm2Image(GraphicsImage):
 
     **Render Methods:**
 
-    :py:class:`KittyImage` provides two methods of :term:`rendering` images, namely:
+    :py:class:`ITerm2Image` provides two methods of :term:`rendering` images, namely:
 
     lines
        Renders an image line-by-line i.e the image if evenly split up across
-       the number of line it should occupy and all portions is joined together by
+       the number of lines it should occupy and all portions are joined together by
        ``\\n`` (newline sequence) to give the whole image.
 
        Pros:
@@ -38,7 +38,7 @@ class ITerm2Image(GraphicsImage):
            image.
 
     whole
-       Renders an image all at once i.e the entire image data is encoded into the first
+       Renders an image all at once i.e the entire image data is encoded into one
        line of the :term:`rendered` output, such that the entire image is drawn once
        by the terminal and still occupies the proper amount of lines and columns.
 
@@ -48,6 +48,10 @@ class ITerm2Image(GraphicsImage):
            compared to the ``lines`` method since the entire image is encoded at once.
          * Better for images that are large in resolution and pixel density.
 
+       .. attention::
+          This method currently doesn't work well on iTerm2 and WezTerm when the image
+          height is greater than the total terminal height.
+
     The render method can be set with
     :py:meth:`set_render_method() <BaseImage.set_render_method>` using the names
     specified above.
@@ -55,9 +59,9 @@ class ITerm2Image(GraphicsImage):
     ATTENTION:
         Currently supported terminal emulators include:
 
-          * `iTerm2 <https://iterm2.com>`_.
-          * `Konsole <https://konsole.kde.org>`_ >= 22.04.0.
-          * `WezTerm <https://wezfurlong.org/wezterm/>`_.
+          * `iTerm2 <https://iterm2.com>`_
+          * `Konsole <https://konsole.kde.org>`_ >= 22.04.0
+          * `WezTerm <https://wezfurlong.org/wezterm/>`_
     """
 
     _render_methods: Set[str] = {LINES, WHOLE}

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -463,7 +463,7 @@ class ITerm2Image(GraphicsImage):
                 compressed_image = io.BytesIO()
             else:
                 compressed_image = io.BytesIO()
-                img.save(compressed_image, format)
+                img.save(compressed_image, format, quality=95)  # *quality* for JPEG
 
         # clean up
         if img is not self._source:
@@ -487,7 +487,8 @@ class ITerm2Image(GraphicsImage):
                     with PIL.Image.frombytes(
                         img.mode, (width, cell_height), raw_image.read(bytes_per_line)
                     ) as img:
-                        img.save(compressed_image, format)
+                        # *quality* for JPEG
+                        img.save(compressed_image, format, quality=95)
 
                     is_on_wezterm and buffer.write(erase)
                     buffer.write(f"\033]1337;File=size={compressed_image.tell()}")

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -431,30 +431,29 @@ class ITerm2Image(GraphicsImage):
                     line < r_height and buffer.write("\n")
 
                 return buffer.getvalue()
-        else:
-            with compressed_image:
-                control_data = "".join(
-                    (
-                        f"size={compressed_image.tell()};width={r_width}"
-                        f";height={r_height};preserveAspectRatio=0;inline=1"
-                        f"{';doNotMoveCursor=1' * is_on_konsole}:"
-                    )
+
+        # WHOLE
+        with compressed_image:
+            control_data = "".join(
+                (
+                    f"size={compressed_image.tell()};width={r_width}"
+                    f";height={r_height};preserveAspectRatio=0;inline=1"
+                    f"{';doNotMoveCursor=1' * is_on_konsole}:"
                 )
-                return "".join(
-                    (
-                        ""
-                        if is_on_konsole
-                        else f"{erase}{jump_right}\n" * (r_height - 1),
-                        erase,
-                        "" if is_on_konsole else f"\033[{r_height - 1}A",
-                        "\033]1337;File=",
-                        control_data,
-                        standard_b64encode(compressed_image.getvalue()).decode(),
-                        ST,
-                        f"{jump_right}\n" * (r_height - 1) if is_on_konsole else "",
-                        jump_right * is_on_konsole,
-                    )
+            )
+            return "".join(
+                (
+                    "" if is_on_konsole else f"{erase}{jump_right}\n" * (r_height - 1),
+                    erase,
+                    "" if is_on_konsole else f"\033[{r_height - 1}A",
+                    "\033]1337;File=",
+                    control_data,
+                    standard_b64encode(compressed_image.getvalue()).decode(),
+                    ST,
+                    f"{jump_right}\n" * (r_height - 1) if is_on_konsole else "",
+                    jump_right * is_on_konsole,
                 )
+            )
 
 
 ST = "\033\\"

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -30,31 +30,41 @@ class ITerm2Image(GraphicsImage):
 
     :py:class:`ITerm2Image` provides two methods of :term:`rendering` images, namely:
 
-    lines
-       Renders an image line-by-line i.e the image if evenly split up across
-       the number of lines it should occupy and all portions are joined together by
-       ``\\n`` (newline sequence) to give the whole image.
+    lines (default)
+       Renders an image line-by-line i.e the image is evenly split across the number
+       of lines it should occupy.
 
        Pros:
 
          * Good for use cases where it might be required to trim some lines of the
            image.
 
+       Cons:
+
+         * Image drawing is very slow on iTerm2 due to the terminal emulator's
+           performance.
+
     whole
        Renders an image all at once i.e the entire image data is encoded into one
        line of the :term:`rendered` output, such that the entire image is drawn once
-       by the terminal and still occupies the proper amount of lines and columns.
+       by the terminal and still occupies the correct amount of lines and columns.
 
        Pros:
 
          * Render results are more compact (i.e less in character count) than with
            the ``lines`` method since the entire image is encoded at once.
-         * Better for images that are large in resolution and pixel density.
+         * Image drawing is faster than with ``lines`` on most terminals.
          * Smoother animations.
 
-       .. warning::
-          This method currently doesn't work well on iTerm2 and WezTerm when the image
-          height is greater than the total terminal height.
+       Cons:
+
+          * This method currently doesn't work well on iTerm2 and WezTerm when the image
+            height is greater than the terminal height.
+
+    NOTE:
+        The **lines** method is the default only because it works properly in all cases,
+        it's more advisable to use the **whole** method except when the image height is
+        greater than the terminal height or when trimming the image is required.
 
     The render method can be set with
     :py:meth:`set_render_method() <BaseImage.set_render_method>` using the names
@@ -150,8 +160,7 @@ class ITerm2Image(GraphicsImage):
               * *alpha*, *repeat*, *cached* and *style* do not apply.
               * Always infinite.
               * No control over frame duration.
-              * Not all animated image formats are supported by all supported
-                terminal emulators.
+              * Not all animated image formats are supported e.g WEBP.
 
             stall_native: Native animation execution control. If:
 
@@ -161,8 +170,7 @@ class ITerm2Image(GraphicsImage):
             kwargs: Keyword arguments passed up the inheritance chain.
 
         Raises:
-            term_image.exceptions.ITerm2ImageError: Native animation is not supported
-              in the :term:`active terminal`.
+            term_image.exceptions.ITerm2ImageError: Native animation is not supported.
 
         See the ``draw()`` method of the parent classes for full details, including the
         description of other parameters.
@@ -258,11 +266,8 @@ class ITerm2Image(GraphicsImage):
                 raise _style_error(type(self))(
                     "Native animation is not supported in the active terminal"
                 )
-            if self._TERM == "wezterm" and img.format == "WEBP":
-                raise _style_error(type(self))(
-                    "Native WEBP animation is not supported in the active terminal"
-                )
-
+            if img.format == "WEBP":
+                raise _style_error(type(self))("Native WEBP animation is not supported")
             try:
                 print(
                     self._format_render(

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+
+from ..utils import lock_tty, query_terminal, read_tty
+from .common import GraphicsImage
+
+
+class ITerm2Image(GraphicsImage):
+    """A render style using the iTerm2 inline image protocol.
+
+    See :py:class:`GraphicsImage` for the complete description of the constructor.
+
+    ATTENTION:
+        Currently supported terminal emulators include:
+
+          * `ITerm2 <https://iterm2.com>`_.
+          * `Konsole <https://konsole.kde.org>`_ >= 22.04.0.
+          * `WezTerm <https://wezfurlong.org/wezterm/>`_.
+    """
+
+    _TERM: str = ""
+    _TERM_VERSION: str = ""
+
+    @classmethod
+    @lock_tty  # the terminal's response to the query is not read all at once
+    def is_supported(cls):
+        if cls._supported is None:
+            # Terminal name/version query + terminal attribute query
+            # The latter is to speed up the entirequery since most (if not all)
+            # terminals should support it and most terminals treat queries as FIFO
+            response = query_terminal(
+                b"\033[>q\033[c", lambda s: not s.endswith(b"\033[?6")
+            ).decode()
+            read_tty()  # The rest of the response to `CSI c`
+
+            # Not supported if the terminal doesn't respond to either query
+            # or responds to the second but not the first
+            if response:
+                match = re.fullmatch(
+                    r"\033P>\|(\w+)[( ]([^\033]+)\)?\033\\",
+                    response.rpartition("\033")[0],
+                )
+                if match and match.group(1).lower() in {"iterm2", "konsole", "wezterm"}:
+                    name, version = map(str.lower, match.groups())
+                    try:
+                        if name == "konsole" and (
+                            tuple(map(int, version.split("."))) < (22, 4, 0)
+                        ):
+                            cls._supported = False
+                        else:
+                            cls._supported = True
+                            cls._TERM, cls._TERM_VERSION = name, version
+                    except ValueError:  # version string not "understood"
+                        cls._supported = False
+            else:
+                cls._supported = False
+
+        return cls._supported

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -79,17 +79,6 @@ class ITerm2Image(GraphicsImage):
 
         [method] [ e {0 | 1} ]
 
-    * ``e``: Cell content erasure workaround for some terminals, particularly WezTerm.
-
-      * If the character after ``e`` is:
-
-        * ``1``, contents of cells in the region covered by the image will be erased.
-        * ``0``, the opposite, thereby allowing existing cell contents to show under
-          transparent areas of the image.
-
-      * If *absent*, defaults to ``e0``.
-      * e.g ``e0``, ``e1``.
-
     * ``method``: Render method override.
 
       Can be one of:
@@ -100,6 +89,17 @@ class ITerm2Image(GraphicsImage):
           images or ``ImageIterator``.
 
       Default: Current effective render method of the image.
+
+    * ``e``: Cell content erasure workaround for some terminals, particularly WezTerm.
+
+      * If the character after ``e`` is:
+
+        * ``1``, contents of cells in the region covered by the image will be erased.
+        * ``0``, the opposite, thereby allowing existing cell contents to show under
+          transparent areas of the image.
+
+      * If *absent*, defaults to ``e0``.
+      * e.g ``e0``, ``e1``.
 
 
     ATTENTION:
@@ -153,7 +153,6 @@ class ITerm2Image(GraphicsImage):
     def draw(
         self,
         *args,
-        animate: bool = True,
         erase: bool = False,
         native: bool = False,
         stall_native: bool = True,
@@ -165,7 +164,6 @@ class ITerm2Image(GraphicsImage):
 
         Args:
             args: Positional arguments passed up the inheritance chain.
-            animate: See :py:meth:`BaseImage.draw`.
             erase: A workaround to erase contents of cells within the region covered
               by the image on some terminal emulators, particularly WezTerm. If:
 
@@ -196,8 +194,11 @@ class ITerm2Image(GraphicsImage):
         See the ``draw()`` method of the parent classes for full details, including the
         description of other parameters.
         """
-        if not (self._is_animated and animate):
-            native = stall_native = False
+        if not (self._is_animated and kwargs.get("animate", True)):
+            # Prevent the arguments from being passed on
+            native = False
+            stall_native = True
+
         arguments = locals()
         super().draw(
             *args,

--- a/term_image/image/iterm2.py
+++ b/term_image/image/iterm2.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ("ITerm2Image",)
+
 import io
 import re
 import sys

--- a/term_image/logging_multi.py
+++ b/term_image/logging_multi.py
@@ -59,6 +59,7 @@ class Process(Process):
         }
         self._main_process_interruped = cli.interrupted
         self._ImageClass = tui.main.ImageClass
+        self._force_style = cli.args.force_style
         self._font_ratio = cli.args.font_ratio
         child_processes.append(self)
 
@@ -67,9 +68,8 @@ class Process(Process):
         _logger.debug("Starting")
 
         try:
-            if self._ImageClass:  # Prevents errors before TUI init
-                # Avoids support checks as the unpickled class object is in the
-                # originally defined state
+            if self._force_style and self._ImageClass:
+                # The unpickled class object is in the originally defined state
                 self._ImageClass._supported = True
 
             if not self._font_ratio:

--- a/term_image/tui/render.py
+++ b/term_image/tui/render.py
@@ -96,6 +96,10 @@ def manage_anim_renders() -> bool:
                 frame_render_in.put((data, size, image_w._ti_alpha))
                 if not next_frame():
                     frame_duration = None
+                try:
+                    del image_w._ti_canv  # Set in `.widgets.Image.render()`
+                except AttributeError:
+                    pass
             else:
                 image_w = data
                 frame_render_in.put(
@@ -436,9 +440,9 @@ anim_render_queue = Queue()
 grid_render_queue = Queue()
 image_render_queue = Queue()
 
-anim_style_specs = {"kitty": "+z"}
+anim_style_specs = {"kitty": "+z", "iterm2": "+Wm1"}
 grid_style_specs = {"kitty": "+z"}
-image_style_specs = {"kitty": "+z"}
+image_style_specs = {"kitty": "+z", "iterm2": "+W"}
 
 # Set from `.tui.init()`
 # # Corresponsing to command-line args


### PR DESCRIPTION
Implementing #48

- Implements support for the iTerm2 inline image protocol.
- Adds the `iterm2` render style.
  - Adds `.image.iterm2` submodule.
  - Adds `ITerm2Image` class.
- Adds `iterm2` choice for `-S | --style`.
- Adds `term_image.TermImageWarning`.
- Adds `--itn/--iterm2-native` and `--itn-max/--iterm2-native-maxsize` style-specific CL options for 'iterm2' native animation.
- Restores support checks in subprocesses.