### PR TITLE
'kitty' render style improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [cli] `--kz/--kitty-z-index` 'kitty' style-specific option ([#49]).
 - [cli] `iterm2` render style choice for the `--style` command-line option ([#50]).
 - [cli] `--itn/--iterm2-native` and `--itn-max/--iterm2-native-maxsize` style-specific CL options for 'iterm2' native animation ([#50]).
+- [cli] `--kc/--kitty-compress` 'kitty' style-specific option ([#51]).
 - [tui] Concurrent/Parallel frame rendering for TUI animations ([#42]).
 - [lib,cli,tui] Support for the Kitty terminal graphics protocol ([#39]).
 - [lib,cli,tui] Automatic render style selection based on the detected terminal support ([#37]).
@@ -73,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/AnonymouX47/term-image/pull/47
 [#49]: https://github.com/AnonymouX47/term-image/pull/49
 [#50]: https://github.com/AnonymouX47/term-image/pull/50
+[#51]: https://github.com/AnonymouX47/term-image/pull/51
 
 
 ## [0.3.1] - 2022-05-04

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1355,7 +1355,13 @@ FOOTNOTES:
                 if args.frame_duration:
                     image.frame_duration = args.frame_duration
 
-                if args.style == "iterm2":
+                if args.style == "kitty":
+                    image.set_render_method(
+                        "lines"
+                        if ImageClass._KITTY_VERSION and image._is_animated
+                        else "whole"
+                    )
+                elif args.style == "iterm2":
                     image.set_render_method(
                         "whole"
                         if (

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1065,7 +1065,11 @@ FOOTNOTES:
         dest="z_index",
         default=0,
         type=int,
-        help="Image stacking order (default: 0)",
+        help=(
+            "Image stacking order (CLI-only) (default: 0). "
+            "`>= 0` -> above text, `< 0` -> below text, `< -(2**31)/2` -> "
+            "below cells with non-default background."
+        ),
     )
     kitty_options.add_argument(
         "--kc",

--- a/term_image/cli.py
+++ b/term_image/cli.py
@@ -1055,7 +1055,7 @@ FOOTNOTES:
 
     kitty_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
     kitty_options = kitty_parser.add_argument_group(
-        "Kitty Style Options (CLI-only)",
+        "Kitty Style Options",
         "These options apply only when the 'kitty' render style is used",
     )
     kitty_options.add_argument(
@@ -1066,6 +1066,18 @@ FOOTNOTES:
         default=0,
         type=int,
         help="Image stacking order (default: 0)",
+    )
+    kitty_options.add_argument(
+        "--kc",
+        "--kitty-compress",
+        metavar="N",
+        dest="compress",
+        default=4,
+        type=int,
+        help=(
+            "ZLIB compression level (CLI/TUI) (default: 4). "
+            "0 -> no compression, 1 -> best speed, 9 -> best compression."
+        ),
     )
 
     iterm2_parser = argparse.ArgumentParser(add_help=False, exit_on_error=False)
@@ -1406,7 +1418,7 @@ FOOTNOTES:
                 notify.notify(str(e), level=notify.ERROR)
     elif OS_IS_UNIX:
         notify.end_loading()
-        tui.init(args, images, contents, ImageClass)
+        tui.init(args, style_args, images, contents, ImageClass)
     else:
         log(
             "The TUI is not supported on Windows! Try with `--cli`.",

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -389,7 +389,8 @@ class KittyImage(GraphicsImage):
                     control_data, raw_image.read(bytes_per_line), compress
                 )
                 z_index is None and buffer.write(clear)
-                buffer.write(trans.get_chunked())
+                for chunk in trans.get_chunks():
+                    buffer.write(chunk)
                 # Writing spaces clears any text under transparent areas of an image
                 for _ in range(r_height - 1):
                     buffer.write(erase)
@@ -399,7 +400,8 @@ class KittyImage(GraphicsImage):
                         control_data, raw_image.read(bytes_per_line), compress
                     )
                     z_index is None and buffer.write(clear)
-                    buffer.write(trans.get_chunked())
+                    for chunk in trans.get_chunks():
+                        buffer.write(chunk)
                 buffer.write(erase)
                 buffer.write(jump_right)
 

--- a/term_image/image/kitty.py
+++ b/term_image/image/kitty.py
@@ -83,8 +83,8 @@ class KittyImage(GraphicsImage):
 
         * ``>= 0``, the image will be drawn above text.
         * ``< 0``, the image will be drawn below text.
-        * ``< -(2 ** 31) / 2``, the image will be drawn below non-default text
-          background colors.
+        * ``< -(2**31)/2``, the image will be drawn below cells with non-default
+          background color.
 
       * ``z`` without ``index`` is currently only used internally.
       * If *absent*, defaults to z-index ``0``.
@@ -183,8 +183,8 @@ class KittyImage(GraphicsImage):
 
               * ``>= 0``, the image will be drawn above text.
               * ``< 0``, the image will be drawn below text.
-              * ``< -(2 ** 31) / 2``, the image will be drawn below non-default text
-                background colors.
+              * ``< -(2**31)/2``, the image will be drawn below cells with
+                non-default background color.
               * ``None``, deletes any directly overlapping image.
 
               .. note::

--- a/term_image/tui/__init__.py
+++ b/term_image/tui/__init__.py
@@ -60,11 +60,15 @@ def init(
     Image._ti_alpha = (
         "#" if args.no_alpha else "#" + (args.alpha_bg or f"{args.alpha:f}"[1:])
     )
-    # KONSOLE does NOT blend images with the same z-index, hence is better off without
-    # `z_index=None`
-    if args.style == "kitty" and ImageClass._KONSOLE_VERSION:
-        for name in ("anim", "grid", "image"):
-            del getattr(render, f"{name}_style_specs")["kitty"]
+
+    # Kitty blends images with the same z-index, hence the `z_index=None`, which is
+    # pretty glitchy for animations with WHOLE method, hence the change to LINES
+    if args.style == "kitty":
+        if ImageClass._KITTY_VERSION:
+            render.anim_style_specs["kitty"] = "+L"
+            for name in ("anim", "grid", "image"):
+                specs = getattr(render, f"{name}_style_specs")
+                specs["kitty"] += "z"
     Image._ti_grid_style_spec = render.grid_style_specs.get(args.style, "")
 
     # daemon, to avoid having to check if the main process has been interrupted

--- a/term_image/tui/__init__.py
+++ b/term_image/tui/__init__.py
@@ -6,7 +6,7 @@ import argparse
 import logging as _logging
 import os
 from pathlib import Path
-from typing import Iterable, Iterator, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, Tuple, Union
 
 import urwid
 
@@ -20,6 +20,7 @@ from .widgets import Image, info_bar, main as main_widget, notif_bar, pile
 
 def init(
     args: argparse.Namespace,
+    style_args: Dict[str, Any],
     images: Iterable[Tuple[str, Union[Image, Iterator]]],
     contents: dict,
     ImageClass: type,
@@ -66,9 +67,11 @@ def init(
     if args.style == "kitty":
         if ImageClass._KITTY_VERSION:
             render.anim_style_specs["kitty"] = "+L"
-            for name in ("anim", "grid", "image"):
-                specs = getattr(render, f"{name}_style_specs")
+        for name in ("anim", "grid", "image"):
+            specs = getattr(render, f"{name}_style_specs")
+            if ImageClass._KITTY_VERSION:
                 specs["kitty"] += "z"
+            specs["kitty"] += f"c{style_args['compress']}"
     Image._ti_grid_style_spec = render.grid_style_specs.get(args.style, "")
 
     # daemon, to avoid having to check if the main process has been interrupted

--- a/term_image/tui/render.py
+++ b/term_image/tui/render.py
@@ -440,9 +440,10 @@ anim_render_queue = Queue()
 grid_render_queue = Queue()
 image_render_queue = Queue()
 
-anim_style_specs = {"kitty": "+z", "iterm2": "+Wm1"}
-grid_style_specs = {"kitty": "+z"}
-image_style_specs = {"kitty": "+z", "iterm2": "+W"}
+# Updated from `.tui.init()`
+anim_style_specs = {"kitty": "+W", "iterm2": "+Wm1"}
+grid_style_specs = {"kitty": "+L"}
+image_style_specs = {"kitty": "+W", "iterm2": "+W"}
 
 # Set from `.tui.init()`
 # # Corresponsing to command-line args

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -69,6 +69,8 @@ def test_style_format_spec():
 
     for spec, args in (
         ("", {}),
+        ("L", {"method": LINES}),
+        ("W", {"method": WHOLE}),
         ("z", {"z_index": None}),
         ("z0", {"z_index": 0}),
         ("z1", {"z_index": 1}),
@@ -77,7 +79,7 @@ def test_style_format_spec():
         (f"z{-2**31}", {"z_index": -(2**31)}),
         ("m0", {"mix": False}),
         ("m1", {"mix": True}),
-        ("z0m1", {"z_index": 0, "mix": True}),
+        ("Wz0m1", {"method": WHOLE, "z_index": 0, "mix": True}),
     ):
         assert KittyImage._check_style_format_spec(spec, spec) == args
 
@@ -88,6 +90,16 @@ class TestStyleArgs:
             with pytest.raises(KittyImageError, match="Unknown style-specific"):
                 KittyImage._check_style_args(args)
 
+    def test_method(self):
+        for value in (1.0, (), [], 2):
+            with pytest.raises(TypeError):
+                KittyImage._check_style_args({"method": value})
+        for value in ("", " ", "cool"):
+            with pytest.raises(ValueError):
+                KittyImage._check_style_args({"method": value})
+        for value in (LINES, WHOLE):
+            assert KittyImage._check_style_args({"method": value}) == {"method": value}
+
     def test_z_index(self):
         for value in (1.0, (), [], "2"):
             with pytest.raises(TypeError):
@@ -96,14 +108,17 @@ class TestStyleArgs:
             with pytest.raises(ValueError):
                 KittyImage._check_style_args({"z_index": value})
         for value in (None, 0, 1, -1, -(2**31), 2**31 - 1):
-            KittyImage._check_style_args({"z_index": value}) == {"z_index": value}
+            assert (
+                KittyImage._check_style_args({"z_index": value})
+                == {"z_index": value}  # fmt: skip
+            )
 
     def test_mix(self):
         for value in (0, 1.0, (), [], "2"):
             with pytest.raises(TypeError):
                 KittyImage._check_style_args({"mix": value})
         for value in (True, False):
-            KittyImage._check_style_args({"mix": value}) == {"mix": value}
+            assert KittyImage._check_style_args({"mix": value}) == {"mix": value}
 
 
 def expand_control_data(control_data):


### PR DESCRIPTION
Continues #40

- Implements render method override for 'kitty' render style.
  - Adds `method` style arg to `KittyImage`.
  - Adds render method override field to 'kitty' style format spec.
- Improves 'kitty' style render method selection for best drawing performance in different terminal emulators, in the CLI and TUI.