### PR TITLE
Improvements to image sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [lib] `term_image.image.Size` enumeration ([#64]).
+  - Implemented "original size" image sizing.
+- [cli] `--fit` and `--original-size` CL options ([#64]).
+
+### Changed
+- [lib] Changed the default value of `size`, `width` and `height` properties to `Size.FIT` ([#64]).
+- [lib] Updated `BaseImage.set_size()` ([#64]).
+  - **(BREAKING!!)** Removed *fit_to_width* and *fit_to_height* parameters.
+  - Now accepts `Size` enum mumbers.
+  - Refer to the linked PR for others.
+- [cli] Changed default sizing to `Size.AUTO` ([#64]).
+- [cli] Changed default padding height to `1` i.e no vertical padding ([#64]).
+- [tui] Changed sizing to `Size.AUTO` for all images ([#64]).
+- [tui] An image/frame is re-rendered only when its size changes, regardless of the canvas size ([#64]).
+
 ### Removed
 - [lib] `term_image.image.TermImage`.
 - [lib] `TermImageException` and `InvalidSize` from `term_image.exceptions`.
 - [lib] Top-level package `term_img`.
+
+[#64]: https://github.com/AnonymouX47/term-image/pull/64
 
 
 ## [0.4.0] - 2022-06-27

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -85,6 +85,26 @@ Below are definitions of terms used across the library's public interface, excep
       
       See also: :ref:`image-scale`.
 
+   automatic size
+   automatic sizing
+      The form of sizing wherein the image size is computed based on the :term:`available size` or the image's original size.
+
+      See also: :py:class:`~term_image.image.Size`.
+
+   dynamic size
+   dynamic sizing
+      The form of sizing wherein the image size is automatically computed at render-time.
+
+      See also: :py:attr:`~term_image.image.BaseImage.size`.
+
+   fixed size
+   fixed sizing
+      The form of sizing wherein the image size is set to a specific value which won't change until it is re-set.
+
+      See also: :py:meth:`~term_image.image.BaseImage.set_size`,
+      :py:attr:`~term_image.image.BaseImage.width` and
+      :py:attr:`~term_image.image.BaseImage.height`.
+
    source
       The resource from which an image is derived.
 

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -30,6 +30,7 @@ Core Library Definitions
    **Class Hierachy:**
 
    * :py:class:`ImageSource`
+   * :py:class:`Size`
    * :py:class:`BaseImage`
 
      * :py:class:`GraphicsImage`
@@ -42,6 +43,10 @@ Core Library Definitions
        * :py:class:`BlockImage`
 
    .. autoclass:: ImageSource
+      :members:
+      :show-inheritance:
+
+   .. autoclass:: Size
       :members:
       :show-inheritance:
 

--- a/docs/source/library/reference/index.rst
+++ b/docs/source/library/reference/index.rst
@@ -59,9 +59,11 @@ There a two categories of render styles:
 Text-based Render Styles
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Represent images using ASCII or Unicode symbols, and in some cases, in conjunction with ANSI colour escape codes.
+Represent images using ASCII or Unicode symbols, and in some cases, with ANSI colour
+escape codes.
 
-Classes for render styles in this category are subclasses of :py:class:`TextImage <term_image.image.TextImage>`. These include:
+Classes for render styles in this category are subclasses of
+:py:class:`TextImage <term_image.image.TextImage>`. These include:
 
 * :py:class:`BlockImage <term_image.image.BlockImage>`
 
@@ -70,7 +72,8 @@ Graphics-based Render Styles
 
 Represent images with actual pixels, using terminal graphics protocols.
 
-Classes for render styles in this category are subclasses of :py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
+Classes for render styles in this category are subclasses of
+:py:class:`GraphicsImage <term_image.image.GraphicsImage>`. These include:
 
 * :py:class:`KittyImage <term_image.image.KittyImage>`
 * :py:class:`ITerm2Image <term_image.image.ITerm2Image>`
@@ -86,12 +89,17 @@ When using **auto font ratio** (in either mode), it's important to note that som
 **See** :ref:`terminal-queries`.
 
 If the program will never expect any useful input, **particularly while an image's
-size is being set or when an image with** :ref:`unset size <unset-size>` **is being
-rendered**, then using ``FULL_AUTO`` mode is OK.
+size is being set/calculated** (for an image with :term:`dynamic size`, while it's
+being rendered or its :py:attr:`~term_image.image.BaseImage.rendered_size`,
+:py:attr:`~term_image.image.BaseImage.rendered_width` or
+:py:attr:`~term_image.image.BaseImage.rendered_height` property is invoked),
+then using ``FULL_AUTO`` mode is OK.
 
 Otherwise i.e if the program will be expecting input, use ``AUTO`` mode and use
 :py:func:`utils.read_tty() <term_image.utils.read_tty>` to read all currently unread
 input just before calling :py:func:`set_font_ratio() <term_image.set_font_ratio>`.
+
+.. note:: This concerns **text-based** render styles only (see the sub-section above).
 
 
 .. _format-spec:

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -31,7 +31,7 @@ from . import (
 from .config import config_options, store_config
 from .exceptions import StyleError, TermImageError, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
-from .image import BlockImage, ITerm2Image, KittyImage, _best_style
+from .image import BlockImage, ITerm2Image, KittyImage, Size, _best_style
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
 from .tui.widgets import Image
@@ -874,12 +874,13 @@ def main() -> None:
             if show_name:
                 notify.notify("\n" + basename(entry[0]) + ":")
             try:
+                if args.width is None is args.height:
+                    args.width = args.auto_size or Size.AUTO
                 image.set_size(
                     args.width,
                     args.height,
                     args.h_allow,
                     args.v_allow,
-                    fit_to_width=args.fit_to_width,
                 )
                 image.scale = (
                     (args.scale_x, args.scale_y) if args.scale is None else args.scale
@@ -912,7 +913,7 @@ def main() -> None:
                             args.h_align,
                             args.pad_width,
                             args.v_align,
-                            args.pad_height,
+                            args.pad_height or 1,
                         )
                     ),
                     (

--- a/src/term_image/image/__init__.py
+++ b/src/term_image/image/__init__.py
@@ -9,6 +9,7 @@ __all__ = (
     "from_file",
     "from_url",
     "ImageSource",
+    "Size",
     "BaseImage",
     "GraphicsImage",
     "TextImage",
@@ -28,6 +29,7 @@ from .common import (  # noqa:F401
     GraphicsImage,
     ImageIterator,
     ImageSource,
+    Size,
     TextImage,
 )
 from .iterm2 import ITerm2Image  # noqa:F401

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -121,7 +121,7 @@ class ImageSource(Enum):
 
 
 class Size(Enum):
-    """Enumeration for automatic image sizing"""
+    """Enumeration for :term:`automatic sizing`"""
 
     #: Equivalent to :py:attr:`ORIGINAL` if it will fit into the
     #: :term:`available size`, else :py:attr:`FIT`.
@@ -144,9 +144,17 @@ class BaseImage(ABC):
 
     Args:
         image: Source image.
-        width: Horizontal dimension of the image, in columns.
-        height: Vertical dimension of the image, in lines.
-        scale: The fraction of the size on respective axes, to render the image with.
+        width: Can be
+
+          * an ``int``; horizontal dimension of the image, in columns.
+          * a :py:class:`~term_image.image.Size` enum member.
+
+        height: Can be
+
+          * an ``int``; vertical dimension of the image, in lines.
+          * a :py:class:`~term_image.image.Size` enum member.
+
+        scale: The fraction of the size (on respective axes) to render the image with.
 
     Raises:
         TypeError: An argument is of an inappropriate type.
@@ -157,13 +165,9 @@ class BaseImage(ABC):
     given.
 
     NOTE:
-        * *width* or *height* is the exact number of columns or lines that'll be used
-          to draw the image (assuming the scale equal `1`), regardless of the currently
-          set :term:`font ratio`.
-        * If neither is given or both are ``None``, the size is automatically determined
-          when the image is to be :term:`rendered`, such that it optimally fits
-          into the terminal.
-        * The image size is multiplied by the :term:`scale` on respective axes before
+        * If neither *width* nor *height* is given (or both are ``None``),
+          :py:attr:`~term_image.image.Size.FIT` applies.
+        * The image size is multiplied by the :term:`scale` on respective axes when
           the image is :term:`rendered`.
         * For animated images, the seek position is initialized to the current seek
           position of the given image.
@@ -300,16 +304,27 @@ class BaseImage(ABC):
         doc="""
         The **unscaled** height of the image.
 
-        ``None`` when the image size is :ref:`unset <unset-size>`.
+        Returns:
 
-        Settable values:
+          * The image height (in lines), if the image size is
+            :term:`fixed <fixed size>`.
+          * A :py:class:`~term_image.image.Size` enum member; if the image size
+            is :term:`dynamic <dynamic size>`.
 
-          * ``None``: Sets the image size to an automatically calculated one,
-            based on the current terminal size.
-          * A positive ``int``: Sets the image height to the given value and
-            the width proportionally.
+        :rtype: Union[Size, int]
 
-        :rtype: int
+        SETTABLE VALUES:
+
+        * a positive ``int``; the image height is set to the given value and the
+          width is set proportionally.
+        * a :py:class:`~term_image.image.Size` enum member; the image size
+          is set as prescibed by the enum member.
+        * ``None``; equivalent to :py:attr:`~term_image.image.Size.FIT`.
+
+        Setting this
+
+        * results in a :term:`fixed size`.
+        * resets the recognized advanced sizing options to their defaults.
         """,
     )
 
@@ -402,7 +417,7 @@ class BaseImage(ABC):
         doc="""
         Image :term:`scale`
 
-        Settable values are:
+        SETTABLE VALUES:
 
           * A *scale value*; sets both axes.
           * A ``tuple`` of two *scale values*; sets ``(x, y)`` respectively.
@@ -459,16 +474,28 @@ class BaseImage(ABC):
         doc="""
         The **unscaled** size of the image.
 
-        ``None`` when the image size is :ref:`unset <unset-size>`.
+        Returns:
 
-        Setting this to ``None`` :ref:`unsets <unset-size>` the image size (so that
-        it's automatically calculated whenever the image is :term:`rendered`) and
-        resets the recognized advanced sizing options to their defaults.
+          * The image size, ``(columns, lines)``, if the image size is
+            :term:`fixed <fixed size>`.
+          * A :py:class:`~term_image.image.Size` enum member, if the image size
+            is :term:`dynamic <dynamic size>`.
 
-        This is multiplied by the :term:`scale` on respective axes before the image
+        :rtype: Union[Size, Tuple[int, int]]
+
+        SETTABLE VALUES:
+
+        * A :py:class:`~term_image.image.Size` enum member; the image size
+          is set as prescibed by the enum member.
+
+        Setting this
+
+        * implies :term:`dynamic sizing` i.e the size is computed whenever the image is
+          :term:`rendered`.
+        * resets the recognized advanced sizing options to their defaults.
+
+        This is multiplied by the :term:`scale` on respective axes when the image
         is :term:`rendered`.
-
-        :rtype: Tuple[int, int]
         """,
     )
 
@@ -505,16 +532,27 @@ class BaseImage(ABC):
         doc="""
         The **unscaled** width of the image.
 
-        ``None`` when the image size is :ref:`unset <unset-size>`.
+        Returns:
 
-        Settable values:
+          * The image width (in columns), if the image size is
+            :term:`fixed <fixed size>`.
+          * A :py:class:`~term_image.image.Size` enum member; if the image size
+            is :term:`dynamic <dynamic size>`.
 
-          * ``None``: Sets the image size to an automatically calculated one,
-            based on the current terminal size.
-          * A positive ``int``: Sets the image width to the given value and
-            the height proportionally.
+        :rtype: Union[Size, int]
 
-        :rtype: int
+        SETTABLE VALUES:
+
+        * a positive ``int``; the image width is set to the given value and the
+          height is set proportionally.
+        * a :py:class:`~term_image.image.Size` enum member; the image size
+          is set as prescibed by the enum member.
+        * ``None``; equivalent to :py:attr:`~term_image.image.Size.FIT`.
+
+        Setting this
+
+        * results in a :term:`fixed size`.
+        * resets the recognized advanced sizing options to their defaults.
         """,
     )
 
@@ -600,13 +638,9 @@ class BaseImage(ABC):
                   undetermined) is used.
                 * A hex color e.g ``ffffff``, ``7faa52``.
 
-            scroll: Only applies to non-animations. If ``True``:
-
-              * and the image size is set, allows the image's
+            scroll: Only applies to non-animations. If ``True``, allows the image's
                 :term:`rendered height` to be greater than the
                 :term:`available terminal height <available height>`.
-              * and the image size is :ref:`unset <unset-size>`, the image is
-                drawn to fit the terminal width.
 
             animate: If ``False``, disable animation i.e draw only the current frame of
               an animated image.
@@ -633,14 +667,13 @@ class BaseImage(ABC):
               can not fit into the :term:`available terminal size <available size>`.
             term_image.exceptions.StyleError: Unrecognized style-specific parameter(s).
 
-        * If :py:meth:`set_size` was directly used to set the image size, the values
-          of the *fit_to_width*, *h_allow* and *v_allow* arguments
-          (when :py:meth:`set_size` was called) are taken into consideration during
-          size validation, with *fit_to_width* applying to only non-animations.
-        * If the size was set via another means or the size is
-          :ref:`unset <unset-size>`, the default values of those parameters are used.
-        * If the image size was set with the *fit_to_width* parameter of
-          :py:meth:`set_size` set to ``True``, then setting *scroll* is unnecessary.
+        * If :py:meth:`set_size` was used to set the image size, the horizontal and
+          vertical allowances (set when :py:meth:`set_size` was called) are taken into
+          consideration during size validation. If the size was set via another means or
+          the size is :term:`dynamic <dynamic size>`, the default allowances apply.
+        * For **non-animations**, if the image size was set with
+          :py:attr:term_image.image.Size.FIT_TO_WIDTH`, the image **height** is not
+          validated and setting *scroll* is unnecessary.
         * *animate*, *repeat* and *cached* apply to :term:`animated` images only.
           They are simply ignored for non-animated images.
         * For animations (i.e animated images with *animate* set to ``True``):
@@ -942,74 +975,49 @@ class BaseImage(ABC):
         """Sets the image size with extended control.
 
         Args:
-            width: Horizontal dimension of the image, in columns.
-            height: Vertical dimension of the image, in lines.
+            width: Can be
+
+              * an ``int``; horizontal dimension of the image, in columns.
+              * a :py:class:`~term_image.image.Size` enum member.
+
+            height: Can be
+
+              * an ``int``; vertical dimension of the image, in lines.
+              * a :py:class:`~term_image.image.Size` enum member.
+
             h_allow: Horizontal allowance i.e minimum number of columns to leave unused.
             v_allow: Vertical allowance i.e minimum number of lines to leave unused.
             maxsize: If given, as ``(columns, lines)``, it's used instead of the
               terminal size.
-            fit_to_width: Only used with **automatic sizing**. See description below.
-            fit_to_height: Only used with **automatic sizing**. See description below.
 
         Raises:
             TypeError: An argument is of an inappropriate type.
             ValueError: An argument is of an appropriate type but has an
               unexpected/invalid value.
             ValueError: Both *width* and *height* are specified.
-            ValueError: *fit_to_width* or *fit_to_height* is ``True`` when *width*,
-              *height* or *maxsize* is given.
-            ValueError: The :term:`available size` is too small for automatic sizing.
+            ValueError: The :term:`available size` is too small for
+              :term:`automatic sizing`.
             term_image.exceptions.InvalidSizeError: *maxsize* is given and the
               resulting size will not fit into it.
 
-        If neither *width* nor *height* is given or anyone given is ``None``,
-        **automatic sizing** applies. In such a case, if:
+        If neither *width* nor *height* is given (or both are ``None``),
+        :py:attr:`~term_image.image.Size.FIT` applies.
 
-          * both *fit_to_width* and *fit_to_height* are ``False``, the size is
-            set to fit **within** the :term:`available terminal size <available size>`
-            (or *maxsize*, if given).
-          * *fit_to_width* is ``True``, the size is set such that the
-            :term:`rendered width` is exactly the
-            :term:`available terminal width <available width>`
-            (assuming the horizontal :term:`scale` equals 1),
-            regardless of the :term:`font ratio`.
-          * *fit_to_height* is ``True``, the size is set such that the
-            :term:`rendered height` is exactly the
-            :term:`available terminal height <available height>`
-            (assuming the vertical :term:`scale` equals 1),
-            regardless of the :term:`font ratio`.
+        If *width* or *height* is a :py:class:`~term_image.image.Size` enum
+        member, :term:`automatic sizing` applies as prescribed by the enum member.
 
-        .. important::
-            1. *fit_to_width* and *fit_to_height* are mutually exclusive.
-               Only one can be ``True`` at a time.
-            2. Neither *fit_to_width* nor *fit_to_height* may be ``True`` when *width*,
-               *height* or *maxsize* is given.
-            3. Be careful when setting *fit_to_height* to ``True`` as it might result
-               in the image's :term:`rendered width` being larger than the terminal
-               width (or maxsize[0]) because :py:meth:`draw` will (by default) raise
-               :py:exc:`term_image.exceptions.InvalidSizeError` if such is the case.
+        When :py:attr:`~term_image.image.Size.FIT_TO_WIDTH` is given,
 
-        | :term:`Vertical allowance` does not apply when *fit_to_width* is ``True``.
-        | :term:`horizontal allowance` does not apply when *fit_to_height* is ``True``.
+        * size validation operations take it into consideration.
+        * :term:`Vertical allowance` is nullified.
 
-        :term:`Allowance`\\ s are ignored when *maxsize* is given.
+        :term:`Allowances <allowance>` are ignored when *maxsize* is given.
 
-        *fit_to_width* might be set to ``True`` to set the image size for
-        vertically-oriented images (i.e images with height > width) such that the
-        drawn image spans more columns but the terminal window has to be scrolled
-        to view the entire image.
+        Image formatting and size validation operations recognize and respect the
+        horizontal and vertical allowances, until the image size is re-set.
 
-        Image formatting and all size validation recognize and respect the values of
-        the *fit_to_width*, *h_allow* and *v_allow* parameters,
-        until the size is re-set or :ref:`unset <unset-size>`.
-
-        *fit_to_height* is only provided for completeness, it should probably be used
-        only when the image will not be drawn to the current terminal.
-        The value of this parameter is **not** recognized by any other method or
-        operation.
-
-        .. note::
-           The size is checked to fit in only when *maxsize* is given along with
+        NOTE:
+           The size is checked to fit in only when *maxsize* is given along with a fixed
            *width* or *height* because :py:meth:`draw` is generally not the means of
            drawing such an image and all rendering methods don't perform any sort of
            size validation.
@@ -1454,7 +1462,7 @@ class BaseImage(ABC):
 
         Args:
             size: If given (in pixels), it is used instead of the pixel-equivalent of
-              the image size (or auto size, if size is unset).
+              the image size.
             pixel_data: If ``False``, ``None`` is returned for all pixel data.
             round_alpha: Only applies when *alpha* is a ``float``.
 
@@ -1997,8 +2005,7 @@ class ImageIterator:
     * If *repeat* equals ``1``, caching is disabled.
     * The iterator has immediate response to changes in the image size
       and :term:`scale`.
-    * If the image size is :ref:`unset <unset-size>`, it's automatically
-      calculated per frame.
+    * If the image size is :term:`dynamic <dynamic size>`, it's computed per frame.
     * The number of the last yielded frame is set as the image's seek position.
     * Directly adjusting the seek position of the image doesn't affect iteration.
       Use :py:meth:`ImageIterator.seek` instead.

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -4,7 +4,14 @@
 
 from __future__ import annotations
 
-__all__ = ("ImageSource", "BaseImage", "GraphicsImage", "TextImage", "ImageIterator")
+__all__ = (
+    "ImageSource",
+    "Size",
+    "BaseImage",
+    "GraphicsImage",
+    "TextImage",
+    "ImageIterator",
+)
 
 import io
 import os
@@ -66,6 +73,15 @@ def _close_validated(func: FunctionType) -> FunctionType:
     return close_validated_wrapper
 
 
+class Hidden:
+    """An object that hides it's original value representation."""
+
+    def __repr__(_):
+        return "<hidden>"
+
+    __ascii__ = __str__ = __repr__
+
+
 class ImageSource(Enum):
     """Image source type.
 
@@ -77,7 +93,7 @@ class ImageSource(Enum):
 
     _ignore_ = ["_SourceAttr"]
 
-    class _SourceAttr(str):
+    class _SourceAttr(Hidden, str):
         """A string that only compares equal to itself but returns the original hash of
         the string.
 
@@ -86,17 +102,13 @@ class ImageSource(Enum):
         """
 
         def __init__(self, *_):
-            self._str = super().__str__()
+            self._str = super(Hidden).__str__()
 
-        def __eq__(*_):
+        def __eq__(self, _):
             return NotImplemented
 
-        def __repr__(self):
-            return "<hidden>"
-
-        __hash__ = str.__hash__
         __ne__ = __eq__
-        __ascii__ = __str__ = __repr__
+        __hash__ = str.__hash__
 
     #: The instance was derived from a path to a local image file.
     FILE_PATH = _SourceAttr("_source")
@@ -106,6 +118,25 @@ class ImageSource(Enum):
 
     #: The instance was derived from an image URL.
     URL = _SourceAttr("_url")
+
+
+class Size(Enum):
+    """Enumeration for automatic image sizing"""
+
+    #: Equivalent to :py:attr:`ORIGINAL` if it will fit into the
+    #: :term:`available size`, else :py:attr:`FIT`.
+    AUTO = Hidden()
+
+    #: The image size is set to fit optimally **within** the :term:`available size`.
+    FIT = Hidden()
+
+    #: The size is set such that the width is exactly the :term:`available width`,
+    #: regardless of the :term:`font ratio`.
+    FIT_TO_WIDTH = Hidden()
+
+    #: The image size is set such that the image is rendered with as many pixels as the
+    #: the original image consists of.
+    ORIGINAL = Hidden()
 
 
 class BaseImage(ABC):

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -2160,12 +2160,6 @@ class ImageIterator:
         n = 0
         while repeat:
             if sent is None:
-                # Size must be set before hashing, since `None` will always
-                # compare equal but doesn't mean the size is the same.
-                unset_size = not image._size
-                if unset_size:
-                    image.set_size()
-
                 image._seek_position = n
                 try:
                     frame = image._format_render(
@@ -2181,9 +2175,6 @@ class ImageIterator:
                 else:
                     if cached:
                         cache[n] = (frame, hash(image.rendered_size))
-                finally:
-                    if unset_size:
-                        image._size = None
 
             sent = yield frame
             n = n + 1 if sent is None else sent - 1
@@ -2193,12 +2184,6 @@ class ImageIterator:
         while repeat:
             while n < n_frames:
                 if sent is None:
-                    # Size must be set before hashing, since `None` will always
-                    # compare equal but doesn't mean the size is the same.
-                    unset_size = not image._size
-                    if unset_size:
-                        image.set_size()
-
                     image._seek_position = n
                     frame, size_hash = cache[n]
                     if hash(image.rendered_size) != size_hash:
@@ -2207,9 +2192,6 @@ class ImageIterator:
                             *fmt,
                         )
                         cache[n] = (frame, hash(image.rendered_size))
-
-                    if unset_size:
-                        image._size = None
 
                 sent = yield frame
                 n = n + 1 if sent is None else sent - 1

--- a/src/term_image/tui/render.py
+++ b/src/term_image/tui/render.py
@@ -10,6 +10,7 @@ from threading import Event
 from typing import Optional, Union
 
 from .. import cli, logging, notify
+from ..image import Size
 from ..logging_multi import Process
 from ..utils import clear_queue
 
@@ -349,7 +350,7 @@ def render_frames(
                 )
                 next(animator)
                 animator.seek(frame_no)
-                image.set_size(maxsize=size)
+                image.set_size(Size.AUTO, maxsize=size)
                 block = False
             else:
                 # A new image is always created to ensure:
@@ -364,7 +365,7 @@ def render_frames(
                 animator = ImageIterator(
                     image, repeat, f"1.1{alpha}{style_spec}", cached
                 )
-                image.set_size(maxsize=size)
+                image.set_size(Size.AUTO, maxsize=size)
                 block = False
 
     clear_queue(output)
@@ -398,7 +399,7 @@ def render_images(
 
         if multi:
             image = ImageClass.from_file(image)
-        image.set_size(maxsize=size)
+        image.set_size(Size.AUTO, maxsize=size)
 
         # Using `BaseImage` for padding will use more memory since all the
         # spaces will be in the render output string, and theoretically more time

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -12,7 +12,7 @@ import urwid
 
 from .. import cli, logging
 from ..config import _nav, cell_width, expand_key, nav
-from ..image import BaseImage
+from ..image import BaseImage, Size
 from ..image.common import _ALPHA_THRESHOLD
 from ..utils import get_terminal_size
 from . import keys, main as tui_main
@@ -328,7 +328,7 @@ class Image(urwid.Widget):
                 None,
                 maxsize=(size[0], get_terminal_size()[1]),
             )
-        image.set_size(maxsize=size)
+        image.set_size(Size.AUTO, maxsize=size)
 
         # Rendering
 

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -267,11 +267,13 @@ class Image(urwid.Widget):
 
         if mul(*image._original_size) > tui_main.MAX_PIXELS and not (
             self._ti_canv
-            # Canvas size will be adjusted later @ Rendering
             and (
-                # Can either be SolidCanvas (faulty) or ImageCanvas
-                not isinstance(self._ti_canv, ImageCanvas)
-                or self._ti_canv._ti_image_size == image.size
+                # will be resized later @ Rendering.
+                self._ti_canv._ti_image_size == image.size
+                # can either be SolidCanvas (faulty) or ImageCanvas
+                if isinstance(self._ti_canv, ImageCanvas)
+                # but faulty shouldn't be resized to allow re-rendering after resize
+                else self._ti_canv.size == size
             )
             or self._ti_rendering
         ):
@@ -346,9 +348,11 @@ class Image(urwid.Widget):
             else:
                 canv.size = size
         elif self._ti_canv and (
+            self._ti_canv._ti_image_size == image.size
             # Can either be SolidCanvas (faulty) or ImageCanvas
-            not isinstance(self._ti_canv, ImageCanvas)
-            or self._ti_canv._ti_image_size == image.size
+            if isinstance(self._ti_canv, ImageCanvas)
+            # but faulty shouldn't be resized to allow re-rendering after resize
+            else self._ti_canv.size == size
         ):
             self._ti_canv.size = size
             canv = self._ti_canv

--- a/tests/test_image_iterator.py
+++ b/tests/test_image_iterator.py
@@ -4,7 +4,7 @@ import pytest
 from PIL import Image
 
 from term_image.exceptions import TermImageError
-from term_image.image import BlockImage, ImageIterator
+from term_image.image import BlockImage, ImageIterator, Size
 from term_image.utils import COLOR_RESET
 
 _size = (30, 15)
@@ -212,18 +212,22 @@ def test_caching():
 
 def test_sizing():
     def test(image_it):
-        for _ in range(2):
-            gif_image2._size = None
-            next(image_it)
-            assert gif_image2._size is None
+        for value in Size:
+            gif_image2.size = value
+            assert next(image_it).count("\n") + 1 == gif_image2.rendered_height
+            assert gif_image2.size is value
 
-            gif_image2._size = (40, 20)
-            assert next(image_it).count("\n") + 1 == 20
-            assert gif_image2._size == (40, 20)
+        gif_image2._size = (40, 20)
+        assert next(image_it).count("\n") + 1 == 20
+        assert gif_image2._size == (40, 20)
 
-            gif_image2._size = (20, 10)
-            assert next(image_it).count("\n") + 1 == 10
-            assert gif_image2._size == (20, 10)
+        gif_image2._size = (20, 10)
+        assert next(image_it).count("\n") + 1 == 10
+        assert gif_image2._size == (20, 10)
+
+        gif_image2.size = Size.FIT
+        next(image_it)
+        assert gif_image2.size is Size.FIT
 
     gif_image2 = BlockImage.from_file(gif_image._source.filename)
 


### PR DESCRIPTION
- Adds `.image.common.Size` enumeration
- Re-implements image size setting
  - Modifies size-related methods and properties
  - Replaces *fit_to_width* parameter of `set_size()` with `Size.FIT_TO_WIDTH`
  - Removes *fit_to_height* parameter of `set_size()` as it seems to lack a realistic use case
  - Redefines terminologies
- Implements original size setting
- Adds `--fit` and `--original-size` CL options
- Changes CLI default sizing to `Size.AUTO`
- Changes CLI default padding height to `1` i.e no vertical padding
- Changes sizing to `Size.AUTO` for all images
- An image/frame is now re-rendered only when its size changes, regardless of the canvas size