### PR TITLE
Public API Update / Eliminate private API use in the CLI/TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [lib,cli] Uppercase letters in hex BG colors being flagged as invalid ([b4533d5])
+- [cli,tui] Crash when `"log file"` or `--log-file` specifies a path with a non-stat-able directory ([#70]).
 
+### Added
+- `auto_style()` to `term_image.image` ([#70]).
+- Render style forced support ([#70]).
+  - `enable_forced_support()` and `disable_forced_support()` to `BaseImage`.
+- Added/Exposed new utilities in `term_image.utils` ([#70]):
+  - `DEFAULT_QUERY_TIMEOUT`
+  - `get_terminal_name_version()`
+  - `get_terminal_size()`
+  - `read_tty_all()`
+  - `write_tty()`
+
+### Removed
+- `term_image.utils.read_tty()` from the public API ([#70]).
+- As much private API usage across the CLI and TUI code ([#70]).
+
+[#70]: https://github.com/AnonymouX47/term-image/pull/70
 [b4533d5]: https://github.com/AnonymouX47/term-image/commit/b4533d5697d41fe0742c2ac895077da3b8d889dc
 
 

--- a/docs/source/library/reference/image.rst
+++ b/docs/source/library/reference/image.rst
@@ -15,6 +15,8 @@ Core Library Definitions
    Since all classes define a common interface, any operation supported by one image
    class can be performed on any other image class, except stated otherwise.
 
+   .. autofunction:: auto_style
+
    .. autofunction:: AutoImage
 
    .. autofunction:: from_file

--- a/docs/source/library/reference/utils.rst
+++ b/docs/source/library/reference/utils.rst
@@ -1,5 +1,5 @@
 .. automodule:: term_image.utils
-   :members: DISABLE_QUERIES, SWAP_WIN_SIZE, lock_tty, read_tty, set_query_timeout
+   :members:
    :show-inheritance:
 
 

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -32,6 +32,7 @@ from .utils import (
     CSI,
     OS_IS_UNIX,
     clear_queue,
+    get_terminal_name_version,
     get_terminal_size,
     set_query_timeout,
     write_tty,
@@ -924,7 +925,7 @@ def main() -> None:
                     image.set_render_method(
                         "lines"
                         if (
-                            ImageClass._KITTY_VERSION
+                            get_terminal_name_version()[0] == "kitty"
                             and image.is_animated
                             and not args.no_anim
                         )

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -689,7 +689,7 @@ def main() -> None:
 
     if args.force_style or args.style is config_options.style != "auto":
         ImageClass.is_supported()  # Some classes need to set some attributes
-        ImageClass._supported = True
+        ImageClass.enable_forced_support()
     else:
         try:
             ImageClass(None)
@@ -703,7 +703,7 @@ def main() -> None:
             )
             return FAILURE
         except TypeError:  # Instantiation is permitted
-            if not ImageClass.is_supported():  # Also sets any required attributes
+            if not ImageClass.is_supported():
                 write_tty(f"{CSI}1K\r".encode())  # Erase emitted APCs
                 log(
                     f"The '{ImageClass}' render style might not be fully supported in "

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -23,7 +23,7 @@ from . import AutoCellRatio, logging, notify, set_cell_ratio, tui, utils
 from .config import config_options, init_config
 from .exceptions import StyleError, TermImageError, TermImageWarning, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
-from .image import BlockImage, ITerm2Image, KittyImage, Size, _best_style
+from .image import BlockImage, ITerm2Image, KittyImage, Size, auto_style
 from .image.common import _ALPHA_BG_FORMAT
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
@@ -685,7 +685,7 @@ def main() -> None:
         "block": BlockImage,
     }[args.style]
     if not ImageClass:
-        ImageClass = _best_style()
+        ImageClass = auto_style()
 
     if args.force_style or args.style is config_options.style != "auto":
         ImageClass.is_supported()  # Some classes need to set some attributes

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -935,7 +935,7 @@ def main() -> None:
                     image.set_render_method(
                         "whole"
                         if (
-                            ImageClass._TERM == "konsole"
+                            get_terminal_name_version()[0] == "konsole"
                             # Always applies to non-native animations also
                             or image.rendered_height <= get_terminal_size()[1]
                         )

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging as _logging
 import os
+import re
 import sys
 import warnings
 from contextlib import suppress
@@ -24,7 +25,6 @@ from .config import config_options, init_config
 from .exceptions import StyleError, TermImageError, TermImageWarning, URLNotFoundError
 from .exit_codes import FAILURE, INVALID_ARG, NO_VALID_SOURCE, SUCCESS
 from .image import BlockImage, ITerm2Image, KittyImage, Size, auto_style
-from .image.common import _ALPHA_BG_FORMAT
 from .logging import Thread, init_log, log, log_exception
 from .logging_multi import Process
 from .tui.widgets import Image
@@ -631,7 +631,7 @@ def main() -> None:
         ("alpha", lambda x: 0.0 <= x < 1.0, "out of range"),
         (
             "alpha_bg",
-            lambda x: not x or _ALPHA_BG_FORMAT.fullmatch("#" + x),
+            lambda x: not x or re.fullmatch("#([0-9a-fA-F]{6})?", "#" + x),
             "invalid hex color",
         ),
     ):

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -725,11 +725,18 @@ def main() -> None:
         ITerm2Image.NATIVE_ANIM_MAXSIZE = style_args.pop("native_maxsize")
         ITerm2Image.READ_FROM_FILE = style_args.pop("read_from_file")
 
-    try:
-        style_args = ImageClass._check_style_args(style_args)
-    except ValueError as e:
-        notify.notify(str(e), notify.CRITICAL)
+    if ImageClass.style in {"kitty", "iterm2"} and not 0 <= style_args["compress"] <= 9:
+        notify.notify(
+            "Compression level must be between 0 and 9, both inclusive "
+            f"(got: {style_args['compress']})",
+            notify.CRITICAL,
+        )
         return INVALID_ARG
+
+    # Remove style-specific args with default values
+    for arg_name, value in tuple(style_args.items()):
+        if value == style_parser.get_default(arg_name):
+            del style_args[arg_name]
 
     if force_cli_mode:
         log(

--- a/src/term_image/cli.py
+++ b/src/term_image/cli.py
@@ -896,7 +896,7 @@ def main() -> None:
 
             if (
                 not args.no_anim
-                and image._is_animated
+                and image.is_animated
                 and not style_args.get("native")
                 and len(images) > 1
             ):
@@ -925,7 +925,7 @@ def main() -> None:
                         "lines"
                         if (
                             ImageClass._KITTY_VERSION
-                            and image._is_animated
+                            and image.is_animated
                             and not args.no_anim
                         )
                         else "whole"

--- a/src/term_image/config.py
+++ b/src/term_image/config.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import urwid
 
 from . import logging, notify
-from .utils import QUERY_TIMEOUT, is_writable
+from .utils import is_writable
 
 
 class ConfigOptions(dict):
@@ -566,7 +566,7 @@ config_options = {
         "must be a boolean",
     ),
     "query timeout": Option(
-        QUERY_TIMEOUT,
+        0.1,
         lambda x: isinstance(x, float) and x > 0.0,
         "must be a float greater than zero",
     ),

--- a/src/term_image/config.py
+++ b/src/term_image/config.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import urwid
 
 from . import logging, notify
+from .utils import DEFAULT_QUERY_TIMEOUT
 
 
 class ConfigOptions(dict):
@@ -597,7 +598,7 @@ config_options = {
         "must be a boolean",
     ),
     "query timeout": Option(
-        0.1,
+        DEFAULT_QUERY_TIMEOUT,
         lambda x: isinstance(x, float) and x > 0.0,
         "must be a float greater than zero",
     ),

--- a/src/term_image/config.py
+++ b/src/term_image/config.py
@@ -8,12 +8,12 @@ import os
 from copy import deepcopy
 from dataclasses import dataclass, field
 from os import path
-from typing import Any, Callable, Dict, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import urwid
 
 from . import logging, notify
-from .utils import is_writable
 
 
 class ConfigOptions(dict):
@@ -55,6 +55,34 @@ class Option:
 
     def __post_init__(self):
         self.value = self.default
+
+
+def is_writable(path: Union[str, os.PathLike, Path]) -> bool:
+    """Checks if a file path is writable or creatable.
+
+    Returns:
+      - ``True``, if:
+        - the file exists and is writable
+        - the file doesn't exists but can be created
+      - ``False``, if:
+        - the path points to a directory
+        - the file exists but is unwritable
+        - the file doesn't exists and cannot be created
+    """
+    path = Path(path).expanduser()
+    writable = False
+
+    if path.exists():
+        if path.is_file() and os.access(path, os.W_OK):
+            writable = True
+    else:
+        for path in path.parents:
+            if path.exists():
+                if path.is_dir() and os.access(path, os.W_OK):
+                    writable = True
+                break
+
+    return writable
 
 
 def action_with_key(key: str, keyset: Dict[str, list]) -> Optional[str]:

--- a/src/term_image/config.py
+++ b/src/term_image/config.py
@@ -72,15 +72,18 @@ def is_writable(path: Union[str, os.PathLike, Path]) -> bool:
     path = Path(path).expanduser()
     writable = False
 
-    if path.exists():
-        if path.is_file() and os.access(path, os.W_OK):
-            writable = True
-    else:
-        for path in path.parents:
-            if path.exists():
-                if path.is_dir() and os.access(path, os.W_OK):
-                    writable = True
-                break
+    try:
+        if path.exists():
+            if path.is_file() and os.access(path, os.W_OK):
+                writable = True
+        else:
+            for path in path.parents:
+                if path.exists():
+                    if path.is_dir() and os.access(path, os.W_OK):
+                        writable = True
+                    break
+    except OSError:  # Fails to stat some directories
+        pass
 
     return writable
 

--- a/src/term_image/image/__init__.py
+++ b/src/term_image/image/__init__.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 __all__ = (
+    "auto_style",
     "AutoImage",
     "from_file",
     "from_url",
@@ -38,6 +39,18 @@ from .iterm2 import ITerm2Image  # noqa:F401
 from .kitty import KittyImage  # noqa:F401
 
 
+def auto_style() -> ImageMeta:
+    """Selects the render style that best suits the current terminal emulator.
+
+    Returns:
+        An image class (a subclass of :py:class:`BaseImage`).
+    """
+    for cls in _styles:
+        if cls.is_supported():
+            break
+    return cls
+
+
 def AutoImage(
     image: PIL.Image.Image,
     *,
@@ -45,52 +58,48 @@ def AutoImage(
     height: Optional[int] = None,
     scale: Tuple[float, float] = (1.0, 1.0),
 ) -> BaseImage:
-    """Convenience function for creating an image instance from a PIL image instance.
+    """Creates an image instance from a PIL image instance.
 
     Returns:
-        An instance of a subclass of :py:class:`BaseImage`.
+        An instance of the automatically selected render style (as returned by
+        :py:func:`auto_style`).
 
     Same arguments and raised exceptions as the :py:class:`BaseImage` class constructor.
     """
-    return _best_style()(image, width=width, height=height, scale=scale)
+    return auto_style()(image, width=width, height=height, scale=scale)
 
 
 def from_file(
     filepath: str,
     **kwargs: Union[None, int, Tuple[float, float]],
 ) -> BaseImage:
-    """Convenience function for creating an image instance from an image file.
+    """Creates an image instance from an image file.
 
     Returns:
-        An instance of a subclass of :py:class:`BaseImage`.
+        An instance of the automatically selected render style (as returned by
+        :py:func:`auto_style`).
 
     Same arguments and raised exceptions as :py:meth:`BaseImage.from_file`.
     """
-    return _best_style().from_file(filepath, **kwargs)
+    return auto_style().from_file(filepath, **kwargs)
 
 
 def from_url(
     url: str,
     **kwargs: Union[None, int, Tuple[float, float]],
 ) -> BaseImage:
-    """Convenience function for creating an image instance from an image URL.
+    """Creates an image instance from an image URL.
 
     Returns:
-        An instance of a subclass of :py:class:`BaseImage`.
+        An instance of the automatically selected render style (as returned by
+        :py:func:`auto_style`).
 
     Same arguments and raised exceptions as :py:meth:`BaseImage.from_url`.
     """
-    return _best_style().from_url(url, **kwargs)
-
-
-def _best_style():
-    for cls in _styles:
-        if cls.is_supported():
-            break
-    return cls
+    return auto_style().from_url(url, **kwargs)
 
 
 # In order of preference, based on image quality and style performance/functionality.
-# NOTE: 'iterm2' should come before 'kitty', if not any other reason, at least because
-# the query for 'kitty' support detection messes up iTerm2's window title.
+# NOTE: 'iterm2' comes before 'kitty' because the query for 'kitty' support detection
+# messes up iTerm2's window title.
 _styles = (ITerm2Image, KittyImage, BlockImage)

--- a/src/term_image/logging_multi.py
+++ b/src/term_image/logging_multi.py
@@ -75,7 +75,7 @@ class Process(Process):
             if self._ImageClass:  # if the TUI is initialized
                 # The unpickled class object is in the originally defined state
                 # Eliminates queries for style support checks
-                self._ImageClass._supported = True
+                self._ImageClass.enable_forced_support()
                 for item in self._style_attrs:
                     setattr(self._ImageClass, *item)
 

--- a/src/term_image/logging_multi.py
+++ b/src/term_image/logging_multi.py
@@ -59,7 +59,7 @@ class Process(Process):
         self._ImageClass = tui.main.ImageClass
         if self._ImageClass:  # if the TUI is initialized
             self._cell_ratio = cli.args.cell_ratio
-            self._query_timeout = utils.QUERY_TIMEOUT
+            self._query_timeout = cli.args.query_timeout
             self._swap_win_size = utils.SWAP_WIN_SIZE
             self._style_attrs = [
                 (attr, getattr(self._ImageClass, attr))
@@ -79,7 +79,7 @@ class Process(Process):
                 for item in self._style_attrs:
                     setattr(self._ImageClass, *item)
 
-                utils.QUERY_TIMEOUT = self._query_timeout
+                utils.set_query_timeout(self._query_timeout)
                 utils.SWAP_WIN_SIZE = self._swap_win_size
 
                 if not self._cell_ratio:

--- a/src/term_image/parsers.py
+++ b/src/term_image/parsers.py
@@ -6,7 +6,6 @@ import sys
 from . import __version__
 from .config import config_options
 from .image import ITerm2Image, Size
-from .image.common import _ALPHA_THRESHOLD
 
 parser = argparse.ArgumentParser(
     prog="term-image",
@@ -244,10 +243,10 @@ alpha_options.add_argument(
     "--alpha",
     type=float,
     metavar="N",
-    default=_ALPHA_THRESHOLD,
+    default=40 / 255,
     help=(
         "Alpha ratio above which pixels are taken as opaque (0 <= x < 1), "
-        f"for text-based render styles (default: {_ALPHA_THRESHOLD:f})"
+        f"for text-based render styles (default: {40 / 255:f})"
     ),
 )
 alpha_options.add_argument(

--- a/src/term_image/tui/keys.py
+++ b/src/term_image/tui/keys.py
@@ -477,7 +477,7 @@ def maximize_cell():
     main_widget.contents[0] = (image_box, ("weight", 1))
 
     image_box.original_widget = image_w
-    if image_w._ti_image._is_animated:
+    if image_w._ti_image.is_animated:
         main.animate_image(image_w)
 
     getattr(main.ImageClass, "clear", lambda: True)()
@@ -497,7 +497,7 @@ def force_render_maximized_cell():
     # Will re-render immediately after processing input, since caching has been disabled
     # for `Image` widgets.
     image_w = image_box._w.contents[1][0].contents[1][0]
-    if image_w._ti_image._is_animated:
+    if image_w._ti_image.is_animated:
         main.animate_image(image_w, True)
     else:
         image_w._ti_force_render = True
@@ -550,7 +550,7 @@ def force_render():
     # Will re-render immediately after processing input, since caching has been disabled
     # for `Image` widgets.
     image_w = main.menu_list[menu.focus_position - 1][1]
-    if image_w._ti_image._is_animated:
+    if image_w._ti_image.is_animated:
         main.animate_image(image_w, True)
     else:
         image_w._ti_force_render = True

--- a/src/term_image/tui/main.py
+++ b/src/term_image/tui/main.py
@@ -48,7 +48,7 @@ from .widgets import (
 def animate_image(image_w: Image, forced_render: bool = False) -> None:
     """Initializes an animation."""
     if not NO_ANIMATION and (
-        mul(*image_w._ti_image._original_size) <= MAX_PIXELS or forced_render
+        mul(*image_w._ti_image.original_size) <= MAX_PIXELS or forced_render
     ):
         try:
             del image_w._ti_anim_finished

--- a/src/term_image/tui/main.py
+++ b/src/term_image/tui/main.py
@@ -244,7 +244,7 @@ def display_images(
                 image_box.set_title(entry)
                 view.original_widget = image_box
                 image_box.original_widget = value
-                if value._ti_image._is_animated:
+                if value._ti_image.is_animated:
                     animate_image(value)
             else:  # Directory
                 grid_acknowledge.clear()

--- a/src/term_image/tui/render.py
+++ b/src/term_image/tui/render.py
@@ -24,7 +24,7 @@ def manage_anim_renders() -> None:
         if not_skip() and (not forced or image_w._ti_force_render):
             if frame:
                 canv = ImageCanvas(frame.encode().split(b"\n"), size, rendered_size)
-                image_w._ti_image._seek_position = frame_no
+                image_w._ti_image.seek(frame_no)
                 image_w._ti_frame = (canv, repeat, frame_no)
             else:
                 image_w._ti_anim_finished = True
@@ -124,7 +124,7 @@ def manage_anim_renders() -> None:
 
                         if next_frame():
                             frame_duration = (
-                                FRAME_DURATION or image_w._ti_image._frame_duration
+                                FRAME_DURATION or image_w._ti_image.frame_duration
                             )
 
                 notify.stop_loading()
@@ -360,7 +360,7 @@ def render_frames(
                 output.put(
                     (
                         next(animator),
-                        animator._loop_no,
+                        animator.loop_no,
                         image.tell(),
                         size,
                         image.rendered_size,

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -264,7 +264,7 @@ class Image(urwid.Widget):
 
         # Forced render
 
-        if mul(*image._original_size) > tui_main.MAX_PIXELS and not (
+        if mul(*image.original_size) > tui_main.MAX_PIXELS and not (
             self._ti_canv
             and (
                 # will be resized later @ Rendering.

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -13,7 +13,6 @@ import urwid
 from .. import logging
 from ..config import config_options, expand_key, navi
 from ..image import BaseImage, Size
-from ..image.common import _ALPHA_THRESHOLD
 from ..utils import get_terminal_name_version, get_terminal_size
 from . import keys, main as tui_main
 from .render import anim_render_queue, grid_render_queue, image_render_queue
@@ -240,8 +239,8 @@ class Image(urwid.Widget):
 
     _ti_grid_cache = {}
 
-    # Updated from `.tui.init()`
-    _ti_alpha = f"{_ALPHA_THRESHOLD}"[1:]
+    # Set from `.tui.init()`
+    _ti_alpha = ""
     _ti_grid_style_spec = ""
 
     def __init__(self, image: BaseImage):

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -14,7 +14,7 @@ from .. import logging
 from ..config import config_options, expand_key, navi
 from ..image import BaseImage, Size
 from ..image.common import _ALPHA_THRESHOLD
-from ..utils import get_terminal_size
+from ..utils import get_terminal_name_version, get_terminal_size
 from . import keys, main as tui_main
 from .render import anim_render_queue, grid_render_queue, image_render_queue
 
@@ -338,7 +338,7 @@ class Image(urwid.Widget):
                     if (
                         # Workaround to erase text on wezterm without glitchy animation
                         tui_main.ImageClass.style == "iterm2"
-                        and tui_main.ImageClass._TERM == "wezterm"
+                        and get_terminal_name_version()[0] == "wezterm"
                     )
                     else __class__._ti_placeholder
                 ).render(size)
@@ -375,7 +375,7 @@ class Image(urwid.Widget):
                     image.is_animated
                     and not tui_main.NO_ANIMATION
                     and tui_main.ImageClass.style == "iterm2"
-                    and tui_main.ImageClass._TERM == "wezterm"
+                    and get_terminal_name_version()[0] == "wezterm"
                 )
                 else __class__._ti_placeholder
             ).render(size)

--- a/src/term_image/tui/widgets.py
+++ b/src/term_image/tui/widgets.py
@@ -281,7 +281,7 @@ class Image(urwid.Widget):
                 # AnimRendermanager or `.tui.main.animate_image()` deletes
                 # `_force_render` when the animation is done to avoid attribute
                 # creation and deletion per frame
-                if image._is_animated and not tui_main.NO_ANIMATION:
+                if image.is_animated and not tui_main.NO_ANIMATION:
                     if not (self._ti_frame or self._ti_anim_finished):
                         self._ti_forced_anim_size_hash = hash(image.size)
                     elif hash(image.size) != self._ti_forced_anim_size_hash:
@@ -358,7 +358,7 @@ class Image(urwid.Widget):
             canv = self._ti_canv
         else:
             if (
-                image._is_animated
+                image.is_animated
                 and not tui_main.NO_ANIMATION
                 and not self._ti_anim_finished
             ):
@@ -372,7 +372,7 @@ class Image(urwid.Widget):
                 placeholder
                 if (
                     # Workaround to erase text on wezterm without glitchy animation
-                    image._is_animated
+                    image.is_animated
                     and not tui_main.NO_ANIMATION
                     and tui_main.ImageClass.style == "iterm2"
                     and tui_main.ImageClass._TERM == "wezterm"

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -6,19 +6,10 @@ Utilities
 from __future__ import annotations
 
 __all__ = (
-    "OS_IS_UNIX",
-    "no_redecorate",
-    "cached",
-    "lock_tty",
-    "unix_tty_only",
-    "terminal_size_cached",
-    "color",
-    "get_cell_size",
-    "get_fg_bg_colors",
+    "DISABLE_QUERIES",
+    "SWAP_WIN_SIZE",
     "get_terminal_size",
-    "get_window_size",
-    "query_terminal",
-    "read_tty",
+    "lock_tty",
     "read_tty_all",
     "set_query_timeout",
     "write_tty",

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -24,7 +24,6 @@ from array import array
 from functools import wraps
 from multiprocessing import Array, Process, Queue as mp_Queue, RLock as mp_RLock
 from operator import floordiv
-from pathlib import Path
 from queue import Empty, Queue
 from shutil import get_terminal_size as _get_terminal_size
 from threading import RLock
@@ -427,34 +426,6 @@ def get_window_size() -> Optional[Tuple[int, int]]:
         size = size[:: -SWAP_WIN_SIZE or 1] if size else (0, 0)
         _win_size_cache[:] = ts + size
         return None if 0 in size else size
-
-
-def is_writable(path: Union[str, os.PathLike, Path]) -> bool:
-    """Checks if a file path is writable or creatable.
-
-    Returns:
-      - ``True``, if:
-        - the file exists and is writable
-        - the file doesn't exists but can be created
-      - ``False``, if:
-        - the path points to a directory
-        - the file exists but is unwritable
-        - the file doesn't exists and cannot be created
-    """
-    path = Path(path).expanduser()
-    writable = False
-
-    if path.exists():
-        if path.is_file() and os.access(path, os.W_OK):
-            writable = True
-    else:
-        for path in path.parents:
-            if path.exists():
-                if path.is_dir() and os.access(path, os.W_OK):
-                    writable = True
-                break
-
-    return writable
 
 
 @unix_tty_only

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -30,7 +30,7 @@ from shutil import get_terminal_size as _get_terminal_size
 from threading import RLock
 from time import monotonic
 from types import FunctionType
-from typing import Callable, Final, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 from .exceptions import TermImageWarning
 
@@ -49,7 +49,7 @@ else:
 #: Default global timeout for :ref:`terminal-queries`
 #:
 #: See also: :py:func:`set_query_timeout`
-DEFAULT_QUERY_TIMEOUT: Final[float] = 0.1
+DEFAULT_QUERY_TIMEOUT: float = 0.1  #: Final[float]
 
 #: If ``True``, :ref:`terminal-queries` are disabled, thereby affecting all
 #: :ref:`dependent features <queried-features>`.

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 __all__ = (
     "DISABLE_QUERIES",
     "SWAP_WIN_SIZE",
+    "get_terminal_name_version",
     "get_terminal_size",
     "lock_tty",
     "read_tty_all",
@@ -320,7 +321,12 @@ def get_fg_bg_colors(
 
 @cached
 def get_terminal_name_version() -> Tuple[Optional[str], Optional[str]]:
-    """Queries the :term:`active terminal` for it's name and version"""
+    """Returns the name and version of the :term:`active terminal`, if available.
+
+    Returns:
+        A 2-tuple, ``(name, version)``. If either is not available, returns ``None``
+        in its place.
+    """
     with _tty_lock:  # the terminal's response to the query is not read all at once
         # Terminal name/version query + terminal attribute query
         # The latter is to speed up the entire query since most (if not all)

--- a/tests/common.py
+++ b/tests/common.py
@@ -154,6 +154,23 @@ def test_is_supported_All():
     assert isinstance(ImageClass.is_supported(), bool)
 
 
+def test_forced_support_Graphics():
+    original = ImageClass._supported
+    try:
+        ImageClass._supported = False
+        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+            ImageClass(python_img)
+
+        ImageClass.enable_forced_support()
+        assert isinstance(ImageClass(python_img), GraphicsImage)
+
+        ImageClass.disable_forced_support()
+        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+            ImageClass(python_img)
+    finally:
+        ImageClass._supported = original
+
+
 def test_set_render_method_All():
     for value in (2, 2.0, ()):
         with pytest.raises(TypeError):


### PR DESCRIPTION
- Makes necessary changes to the API to provide features which are needed publicly but are currently only private or missing.
- Eliminates use of private API in the viewer.
- Prepares for the separation of the viewer from the library.

### Fixes
- [cli,tui] Crash when `"log file"` or `--log-file` specifies a path with a non-stat-able directory.

### Adds
- `auto_style()` to `term_image.image`.
- Render style forced support.
  - `enable_forced_support()` and `disable_forced_support()` to `BaseImage`.
- Added/Exposed new utilities in `term_image.utils`:
  - `DEFAULT_QUERY_TIMEOUT`
  - `get_terminal_name_version()`
  - `get_terminal_size()`
  - `read_tty_all()`
  - `write_tty()`

### Removes
- `term_image.utils.read_tty()` from the public API.
- As much private API usage across the CLI and TUI code.