### PR TITLE
Update image z-index and blending for `kitty` render style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **(BREAKING!)** Redefined `KittyImage.clear()` ([97eceab]).
+- **(BREAKING!)** Changed the valid values for the `z_index` style-specific parameter of the *kitty* render style ([#74]).
+  - `None` is no longer a valid value.
+  - The lower bound of the valid value range is now `-(2**31 - 1)`.
 
 ### Removed
 - The CLI and TUI ([#72]).
@@ -31,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#70]: https://github.com/AnonymouX47/term-image/pull/70
 [#72]: https://github.com/AnonymouX47/term-image/pull/72
+[#74]: https://github.com/AnonymouX47/term-image/pull/74
 [b4533d5]: https://github.com/AnonymouX47/term-image/commit/b4533d5697d41fe0742c2ac895077da3b8d889dc
 [97eceab]: https://github.com/AnonymouX47/term-image/commit/b4533d5697d41fe0742c2ac895077da3b8d889dc
 

--- a/src/term_image/image/kitty.py
+++ b/src/term_image/image/kitty.py
@@ -177,7 +177,8 @@ class KittyImage(GraphicsImage):
         Args:
             cursor: If ``True``, all images intersecting with the current cursor
               position are cleared.
-            z_index: If given, all images on the given z-index are cleared.
+            z_index: An integer in the **signed 32-bit range**. If given, all images
+              on the given z-index are cleared.
             now: If ``True`` the images are cleared immediately. Otherwise they're
               cleared when next Python's standard output buffer is flushed.
 
@@ -195,13 +196,15 @@ class KittyImage(GraphicsImage):
             raise TypeError(f"Invalid type for 'cursor' (got: {type(cursor).__name__})")
 
         if z_index is not None:
-            _, (type_check, _), (value_check, value_msg) = cls._style_args["z_index"]
-            if not type_check(z_index):
+            if not isinstance(z_index, int):
                 raise TypeError(
                     f"Invalid type for 'z_index' (got: {type(z_index).__name__})"
                 )
-            if not value_check(z_index):
-                raise ValueError(value_msg)
+            if not -(1 << 31) <= z_index < (1 << 31):
+                raise ValueError(
+                    "z-index must be within the 32-bit signed integer range "
+                    f"(got: {z_index})"
+                )
 
         if not isinstance(now, bool):
             raise TypeError(f"Invalid type for 'now' (got: {type(now).__name__})")

--- a/src/term_image/image/kitty.py
+++ b/src/term_image/image/kitty.py
@@ -353,11 +353,12 @@ class KittyImage(GraphicsImage):
         See :py:meth:`~term_image.image.BaseImage._clear_frame` for description.
         """
         if cls._KITTY_VERSION and cls._KITTY_VERSION <= (0, 25, 0):
-            cls.clear()
+            cls.clear(z_index=-(1 << 31))
             return True
         return False
 
     def _display_animated(self, *args, **kwargs) -> None:
+        kwargs["z_index"] = -(1 << 31)
         if self._KITTY_VERSION > (0, 25, 0):
             kwargs["blend"] = False
 

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -691,7 +691,7 @@ class TestClear:
             with pytest.raises(TypeError, match="'z_index'"):
                 KittyImage.clear(z_index=value)
 
-        for value in (-(2**31) - 1, 2**31):
+        for value in (-(2**31 + 1), 2**31):
             with pytest.raises(ValueError, match="z-index .* range"):
                 KittyImage.clear(z_index=value)
 
@@ -725,7 +725,7 @@ class TestClear:
             assert tty_buf.getvalue() == b""
 
     def test_z_index(self):
-        for value in range(-10, 11):
+        for value in (-(2**31), *range(-10, 11), 2**31 - 1):
             with self.setup_buffer() as (buf, tty_buf):
                 KittyImage.clear(z_index=value, now=True)
                 assert buf.getvalue() == b""

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -239,9 +239,9 @@ class TestRenderLines:
     trans.height = _size
     trans.set_render_method(LINES)
 
-    def render_image(self, alpha=0.0, *, z=0, m=False, c=4):
+    def render_image(self, alpha=0.0, *, z=0, m=False, c=4, b=True):
         return self.trans._renderer(
-            self.trans._render_image, alpha, z_index=z, mix=m, compress=c
+            self.trans._render_image, alpha, z_index=z, mix=m, compress=c, blend=b
         )
 
     def _test_image_size(self, image):
@@ -436,6 +436,13 @@ class TestRenderLines:
             > len(self.render_image(c=9))
         )
 
+    def test_blend_false(self):
+        self.trans.scale = 1.0
+
+        render = self.render_image(None, b=False)
+        for line in render.splitlines():
+            assert line.startswith(delete)
+
     def test_scaled(self):
         # At varying scales
         for self.trans.scale in map(lambda x: x / 100, range(10, 101, 10)):
@@ -459,9 +466,9 @@ class TestRenderWhole:
     trans.height = _size
     trans.set_render_method(WHOLE)
 
-    def render_image(self, alpha=0.0, z=0, m=False, c=4):
+    def render_image(self, alpha=0.0, z=0, m=False, c=4, b=True):
         return self.trans._renderer(
-            self.trans._render_image, alpha, z_index=z, mix=m, compress=c
+            self.trans._render_image, alpha, z_index=z, mix=m, compress=c, blend=b
         )
 
     def _test_image_size(self, image):
@@ -634,6 +641,12 @@ class TestRenderWhole:
             render = self.render_image(None, c=value)
             assert render == f"{self.trans:1.1#+c{value}}"
             assert ("o", "z") in decode_image(render)[0]
+
+    def test_blend_false(self):
+        self.trans.scale = 1.0
+
+        render = self.render_image(None, b=False)
+        assert render.startswith(delete)
 
     def test_scaled(self):
         # At varying scales


### PR DESCRIPTION
- `None` is no longer a valid value for `z_index` style-specific parameter.
- Changes the lower bound of the valid value range for the `z_index` style-specific parameter to `INT32_MIN + 1`.
  - `KittyImage.clear()` still allows `z_index=INT32_MIN` though.
- Reserves `z_index=INT32_MIN` to be used for non-native animation frames.
- Non-native animation frames are now cleared by z-index instead of clearing all visible images, on kitty <= 0.25.0.
  - Tested and works on kitty v0.25.0.
  - It clears the last frame of a previous animation (if any) but is probably still better than clearing all visible images (who needs just the last frame of an animation anyways?).
- Adds `blend` style parameter (but for internal use only).
  - Replaces `z_index=None` and makes the feature truly private.

The separation of z-index and blending is required by #73