### PR TITLE
Prevent null render size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `None` is no longer a valid value.
   - The lower bound of the valid value range is now `-(2**31 - 1)`.
 - Extended `ITerm2Image.clear()` ([807a9ec]).
+- Computed image size and `image.rendered_size` (regardless of the value of `image.scale`) can no longer be null (contain `0`) ([#78]).
+  - No more "Image size or scale too small" error at render time.
 
 ### Removed
 - The CLI and TUI ([#72]).
@@ -45,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#72]: https://github.com/AnonymouX47/term-image/pull/72
 [#73]: https://github.com/AnonymouX47/term-image/pull/73
 [#74]: https://github.com/AnonymouX47/term-image/pull/74
+[#78]: https://github.com/AnonymouX47/term-image/pull/78
 [b4533d5]: https://github.com/AnonymouX47/term-image/commit/b4533d5697d41fe0742c2ac895077da3b8d889dc
 [97eceab]: https://github.com/AnonymouX47/term-image/commit/97eceab77e7448a18281aa6edb3fa8ec9e6564c5
 [807a9ec]: https://github.com/AnonymouX47/term-image/commit/807a9ecad717e46621a5214dbf849369d3afbc0b

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -740,8 +740,7 @@ class BaseImage(metaclass=ImageMeta):
             TypeError: An argument is of an inappropriate type.
             ValueError: An argument is of an appropriate type but has an
               unexpected/invalid value.
-            ValueError: Unable to convert image.
-            ValueError: Image size or :term:`scale` too small.
+            ValueError: Unable to convert or resize image.
             term_image.exceptions.InvalidSizeError: The image's :term:`rendered size`
               can not fit into the :term:`available terminal size <available size>`.
             term_image.exceptions.StyleError: Unrecognized style-specific parameter(s).
@@ -1582,6 +1581,7 @@ class BaseImage(metaclass=ImageMeta):
                 prev_img = img
                 try:
                     img = img.convert(mode)
+                # Possible for images in some modes e.g "La"
                 except Exception as e:
                     raise ValueError("Unable to convert image") from e
                 finally:
@@ -1592,8 +1592,9 @@ class BaseImage(metaclass=ImageMeta):
                 prev_img = img
                 try:
                     img = img.resize(size, Image.Resampling.BOX)
-                except ValueError as e:
-                    raise ValueError("Image size or scale too small") from e
+                # Highly unlikely since render size can never be zero
+                except Exception as e:
+                    raise ValueError("Unable to resize image") from e
                 finally:
                     if frame_img is not prev_img is not self._source:
                         prev_img.close()

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -1893,18 +1893,20 @@ class BaseImage(metaclass=ImageMeta):
                 )
             elif Size.FIT_TO_WIDTH in (width, height):
                 return (
-                    self._pixels_cols(pixels=max_width),
+                    self._pixels_cols(pixels=max_width) or 1,
                     self._pixels_lines(
                         pixels=round(
                             self._width_height_px(w=max_width) * self._pixel_ratio
                         )
-                    ),
+                    )
+                    or 1,
                 )
 
             if Size.ORIGINAL in (width, height):
                 return (
-                    self._pixels_cols(pixels=ori_width),
-                    self._pixels_lines(pixels=round(ori_height * self._pixel_ratio)),
+                    self._pixels_cols(pixels=ori_width) or 1,
+                    self._pixels_lines(pixels=round(ori_height * self._pixel_ratio))
+                    or 1,
                 )
 
             # The smaller fraction will fit on both axis.
@@ -1936,8 +1938,8 @@ class BaseImage(metaclass=ImageMeta):
                 # Round the width
                 width_px = round(width_px)
             return (
-                self._pixels_cols(pixels=width_px),
-                self._pixels_lines(pixels=height_px),
+                self._pixels_cols(pixels=width_px) or 1,
+                self._pixels_lines(pixels=height_px) or 1,
             )
         elif width is None:
             width_px = round(
@@ -1958,7 +1960,7 @@ class BaseImage(metaclass=ImageMeta):
                 f"'maxsize' {maxsize}"
             )
 
-        return (width, height)
+        return (width or 1, height or 1)
 
     def _width_height_px(
         self, *, w: Optional[int] = None, h: Optional[int] = None

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -421,7 +421,8 @@ class BaseImage(metaclass=ImageMeta):
                 else self._size
             )[1]
             * self._scale[1]
-        ),
+        )
+        or 1,
         doc="""
         The **scaled** height of the image.
 
@@ -434,15 +435,18 @@ class BaseImage(metaclass=ImageMeta):
     rendered_size = property(
         lambda self: tuple(
             map(
-                round,
+                lambda x: x or 1,
                 map(
-                    mul,
-                    (
-                        self._valid_size(self._size, None)
-                        if isinstance(self._size, Size)
-                        else self._size
+                    round,
+                    map(
+                        mul,
+                        (
+                            self._valid_size(self._size, None)
+                            if isinstance(self._size, Size)
+                            else self._size
+                        ),
+                        self._scale,
                     ),
-                    self._scale,
                 ),
             )
         ),
@@ -464,7 +468,8 @@ class BaseImage(metaclass=ImageMeta):
                 else self._size
             )[0]
             * self._scale[0]
-        ),
+        )
+        or 1,
         doc="""
         The **scaled** width of the image.
 

--- a/tests/test_image/test_base.py
+++ b/tests/test_image/test_base.py
@@ -256,8 +256,8 @@ class TestProperties:
         for value in range(1, 101):
             scale = value / 100
             image.scale = scale
-            assert image.rendered_width == round(_width * scale)
-            assert image.rendered_height == round(_height * scale)
+            assert 0 != image.rendered_width == (round(_width * scale) or 1)
+            assert 0 != image.rendered_height == (round(_height * scale) or 1)
 
         # Random scales
         for _ in range(100):
@@ -265,8 +265,8 @@ class TestProperties:
             if scale == 0:
                 continue
             image.scale = scale
-            assert image.rendered_width == round(_width * scale)
-            assert image.rendered_height == round(_height * scale)
+            assert 0 != image.rendered_width == (round(_width * scale) or 1)
+            assert 0 != image.rendered_height == (round(_height * scale) or 1)
 
         image.scale = 1.0
 

--- a/tests/test_image/test_base.py
+++ b/tests/test_image/test_base.py
@@ -569,21 +569,6 @@ class TestRenderData:
             img or self.trans._get_image(), alpha, **kwargs
         )
 
-    def test_small_size_scale(self):
-        try:
-            for self.trans._size in ((1, 0), (0, 1), (0, 0)):
-                with pytest.raises(ValueError, match="too small"):
-                    self.get_render_data(None)
-        finally:
-            self.trans.height = _size
-
-        try:
-            self.trans.scale = 0.0001
-            with pytest.raises(ValueError, match="too small"):
-                self.get_render_data(None)
-        finally:
-            self.trans.scale = 1.0
-
     def test_alpha(self):
 
         # float

--- a/tests/test_image/test_block.py
+++ b/tests/test_image/test_block.py
@@ -113,8 +113,8 @@ class TestRender:
             if scale == 0.0:
                 continue
             self.trans.scale = scale
-            if 0 in self.trans.rendered_size:
-                continue
+            assert 0 not in self.trans.rendered_size
+
             render = self.render_image(_ALPHA_THRESHOLD)
             assert render.count("\n") + 1 == self.trans.rendered_height
             assert all(

--- a/tests/test_image/test_iterm2.py
+++ b/tests/test_image/test_iterm2.py
@@ -414,8 +414,8 @@ class TestRenderLines:
             if scale == 0.0:
                 continue
             self.trans.scale = scale
-            if 0 in self.trans.rendered_size:
-                continue
+
+            assert 0 not in self.trans.rendered_size
             for ITerm2Image._TERM in supported_terminals:
                 self._test_image_size(self.trans, term=ITerm2Image._TERM)
 
@@ -699,8 +699,8 @@ class TestRenderWhole:
             if scale == 0.0:
                 continue
             self.trans.scale = scale
-            if 0 in self.trans.rendered_size:
-                continue
+
+            assert 0 not in self.trans.rendered_size
             for ITerm2Image._TERM in supported_terminals:
                 self._test_image_size(self.trans, term=ITerm2Image._TERM)
 

--- a/tests/test_image/test_kitty.py
+++ b/tests/test_image/test_kitty.py
@@ -455,8 +455,8 @@ class TestRenderLines:
             if scale == 0.0:
                 continue
             self.trans.scale = scale
-            if 0 in self.trans.rendered_size:
-                continue
+
+            assert 0 not in self.trans.rendered_size
             self._test_image_size(self.trans)
 
 
@@ -660,8 +660,8 @@ class TestRenderWhole:
             if scale == 0.0:
                 continue
             self.trans.scale = scale
-            if 0 in self.trans.rendered_size:
-                continue
+
+            assert 0 not in self.trans.rendered_size
             self._test_image_size(self.trans)
 
 


### PR DESCRIPTION
Closes #75

- Modifies image size computation (`BaseImage._valid_size()`) to ensure `0` is never returned for either dimension.
- Modifies `image,rendered_size` to never contain a zero, no matter the scale.
- "Image size or scale too small" exception can no longer be raised at render time.