### PR TITLE
Implement synchronized output for urwid images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `term_image.widget` subpackage
   - `term_image.widget.UrwidImage`
   - `term_image.widget.UrwidImageCanvas`
-  - `term_image.widget.UrwidImageJanitor`
   - `term_image.widget.UrwidImageScreen`
+    - Support for terminal-synchronized output ([#80]).
 
 ### Changed
 - **(BREAKING!)** Redefined `KittyImage.clear()` ([97eceab]).
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/AnonymouX47/term-image/pull/73
 [#74]: https://github.com/AnonymouX47/term-image/pull/74
 [#78]: https://github.com/AnonymouX47/term-image/pull/78
+[#80]: https://github.com/AnonymouX47/term-image/pull/80
 [b4533d5]: https://github.com/AnonymouX47/term-image/commit/b4533d5697d41fe0742c2ac895077da3b8d889dc
 [97eceab]: https://github.com/AnonymouX47/term-image/commit/97eceab77e7448a18281aa6edb3fa8ec9e6564c5
 [807a9ec]: https://github.com/AnonymouX47/term-image/commit/807a9ecad717e46621a5214dbf849369d3afbc0b

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -692,6 +692,17 @@ FG_FMT = f"{CSI}38;2;%d;%d;%dm"
 FG_FMT_b = FG_FMT.encode()
 COLOR_RESET = f"{CSI}m"
 COLOR_RESET_b = COLOR_RESET.encode()
+DECSET = f"{CSI}?%dh"
+DECSET_b = DECSET.encode()
+DECRST = f"{CSI}?%dl"
+DECRST_b = DECRST.encode()
+
+# Terminal Synchronized Output
+# See https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
+BEGIN_SYNCED_UPDATE = DECSET % 2026
+BEGIN_SYNCED_UPDATE_b = BEGIN_SYNCED_UPDATE.encode()
+END_SYNCED_UPDATE = DECRST % 2026
+END_SYNCED_UPDATE_b = END_SYNCED_UPDATE.encode()
 
 # Private internal variables
 _query_timeout = DEFAULT_QUERY_TIMEOUT

--- a/src/term_image/widget/__init__.py
+++ b/src/term_image/widget/__init__.py
@@ -9,12 +9,7 @@ try:
 except ImportError:
     pass
 else:
-    from .urwid import UrwidImage, UrwidImageCanvas, UrwidImageJanitor, UrwidImageScreen
+    from .urwid import UrwidImage, UrwidImageCanvas, UrwidImageScreen
 
     del urwid
-    __all__ += [
-        "UrwidImage",
-        "UrwidImageCanvas",
-        "UrwidImageJanitor",
-        "UrwidImageScreen",
-    ]
+    __all__ += ["UrwidImage", "UrwidImageCanvas", "UrwidImageScreen"]

--- a/src/term_image/widget/urwid.py
+++ b/src/term_image/widget/urwid.py
@@ -598,9 +598,11 @@ class UrwidImageJanitor(urwid.WidgetWrap):
 
 
 class UrwidImageScreen(urwid.raw_display.Screen):
-    """A screen that clears all visible images of the
-    :py:class:`kitty <term_image.image.KittyImage>` render style immediately after
-    it starts and immediately before it stops.
+    """A screen that supports drawing images.
+
+    It monitors images of some :ref:`graphics-based <graphics-based>` render styles
+    and clears them off the screen when necessary (e.g at startup, when scrolling,
+    upon terminal resize and at exit).
 
     See the `baseclass
     <http://urwid.org/reference/display_modules.html#urwid.raw_display.Screen>`_

--- a/src/term_image/widget/urwid.py
+++ b/src/term_image/widget/urwid.py
@@ -10,7 +10,7 @@ import urwid
 
 from ..exceptions import UrwidImageError
 from ..image import BaseImage, ITerm2Image, KittyImage, Size, TextImage, kitty
-from ..utils import COLOR_RESET_b, ESC_b
+from ..utils import BEGIN_SYNCED_UPDATE, END_SYNCED_UPDATE, COLOR_RESET_b, ESC_b
 
 # NOTE: Any new "private" attribute of any subclass of an urwid class should be
 # prepended with "_ti" to prevent clashes with names used by urwid itself.
@@ -613,10 +613,15 @@ class UrwidImageScreen(urwid.raw_display.Screen):
         self._ti_image_cviews = frozenset()
 
     def draw_screen(self, maxres, canvas):
-        if canvas is not self._ti_screen_canv:
-            self._ti_screen_canv = canvas
-            self._ti_clear_images()
-        ret = super().draw_screen(maxres, canvas)
+        self.write(BEGIN_SYNCED_UPDATE)
+        try:
+            if canvas is not self._ti_screen_canv:
+                self._ti_screen_canv = canvas
+                self._ti_clear_images()
+            ret = super().draw_screen(maxres, canvas)
+        finally:
+            self.write(END_SYNCED_UPDATE)
+            self.flush()
 
         return ret
 

--- a/src/term_image/widget/urwid.py
+++ b/src/term_image/widget/urwid.py
@@ -507,6 +507,9 @@ class UrwidImageScreen(urwid.raw_display.Screen):
     and clears them off the screen when necessary (e.g at startup, when scrolling,
     upon terminal resize and at exit).
 
+    It also synchronizes output on terminal emulators that support the feature to
+    reduce/eliminate image flickering/tearing.
+
     See the `baseclass
     <http://urwid.org/reference/display_modules.html#urwid.raw_display.Screen>`_
     for futher description.


### PR DESCRIPTION
Partially implements #79

- Moves automatic image clearing into `UrwidImageScreen.draw_screen()`.
- Removes `UrwidImageJanitor` in favour of `UrwidImageScreen`.
- Adds support for synchronized output to `UrwidImageScreen`.
  - Reduces/Eliminates image flickering/tearing on supporting terminal emulators.