### PR TITLE
Remove restrictions on *iterm2* native animation

### DIFF
--- a/docs/source/reference/image.rst
+++ b/docs/source/reference/image.rst
@@ -96,7 +96,7 @@ The Classes
 |
 
 .. autoclass:: ITerm2Image
-   :exclude-members: is_supported
+   :exclude-members: draw, is_supported
 
 |
 

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -480,19 +480,26 @@ class ITerm2Image(GraphicsImage):
                 control_data = "".join(
                     (
                         f"size={compressed_image.tell()};width={r_width}"
-                        f";height={r_height};preserveAspectRatio=0;inline=1:"
+                        f";height={r_height};preserveAspectRatio=0;inline=1"
+                        f"{';doNotMoveCursor=1' * is_on_konsole}:"
                     )
                 )
                 compressed_image.seek(0)
                 return "".join(
                     (
-                        f"{erase}{jump_right}\n" * (r_height - 1),
+                        (
+                            ""
+                            if is_on_konsole
+                            else f"{erase}{jump_right}\n" * (r_height - 1)
+                        ),
                         erase,
-                        jump_up,
+                        "" if is_on_konsole else jump_up,
                         START,
                         control_data,
                         standard_b64encode(compressed_image.read()).decode(),
                         ST,
+                        f"{jump_right}\n" * (r_height - 1) if is_on_konsole else "",
+                        jump_right * is_on_konsole,
                     )
                 )
 

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -310,13 +310,6 @@ class ITerm2Image(GraphicsImage):
             )
 
     def draw(self, *args, **kwargs):
-        """Draws an image to standard output.
-
-        Raises:
-            term_image.exceptions.ITerm2ImageError: Native animation is not supported.
-
-        See the :py:meth:`BaseImage.draw` for the full description.
-        """
         # Ignore (and omit) native animation arguments for non-animations
         if not (self._is_animated and kwargs.get("animate", True)):
             for arg_name in ("native", "stall_native"):
@@ -374,14 +367,6 @@ class ITerm2Image(GraphicsImage):
         **kwargs,
     ):
         if native:
-            if self._TERM == "konsole":
-                self._close_image(img)
-                raise _style_error(type(self))(
-                    "Native animation is not supported in the active terminal"
-                )
-            if img.format == "WEBP":
-                self._close_image(img)
-                raise _style_error(type(self))("Native WEBP animation is not supported")
             try:
                 print(
                     self._format_render(
@@ -458,7 +443,7 @@ class ITerm2Image(GraphicsImage):
             except (AttributeError, OSError):
                 file_is_readable = False
 
-        if native and self._is_animated and not frame and img.format != "WEBP":
+        if native and self._is_animated and not frame:
             if self._source_type is ImageSource.PIL_IMAGE:
                 if file_is_readable:
                     compressed_image = open(img.filename, "rb")

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -115,18 +115,16 @@ class ITerm2Image(GraphicsImage):
       * *default* → ``4``
       * Results in a trade-off between render time and data size/draw speed
 
-    * **native** (*bool*) → Native animation policy.
+    * **native** (*bool*) → Native animation policy. [1]_
 
       * ``True`` → use the protocol's native animation feature
       * ``False`` → use the normal animation
       * *default* → ``False``
-      * Ignored if the image is not animated or *animate* is ``False``
-      * The terminal emulator completely controls the animation
       * *alpha*, *repeat*, *cached* and *style* do not apply
-      * Uses the **WHOLE** render method
+      * Ignored if the image is not animated or *animate* is ``False``
       * Normal restrictions for sizing of animations do not apply
-      * Not all animated image formats are supported e.g WEBP
-      * Not all terminal emulators implement this feature of the protocol e.g Konsole
+      * Uses **WHOLE** render method
+      * The terminal emulator completely controls the animation
 
     * **stall_native** (*bool*) → Native animation execution control.
 
@@ -148,8 +146,8 @@ class ITerm2Image(GraphicsImage):
 
       * ``L`` → **LINES** render method (current frame only, for animated images)
       * ``W`` → **WHOLE** render method (current frame only, for animated images)
-      * ``N`` → Native animation (ignored when used with non-animated images, WEBP
-        animated images or :py:class:`~term_image.image.ImageIterator`)
+      * ``N`` → Native animation [1]_ (ignored when used with non-animated images or
+        :py:class:`~term_image.image.ImageIterator`)
       * *default* → current effective render method of the instance
 
     * ``m`` → cell content inter-mix policy (**Only supported in WezTerm**, ignored
@@ -184,6 +182,15 @@ class ITerm2Image(GraphicsImage):
         * `iTerm2 <https://iterm2.com>`_
         * `Konsole <https://konsole.kde.org>`_ >= 22.04.0
         * `WezTerm <https://wezfurlong.org/wezterm/>`_
+
+    .. [1] Native animation support:
+
+       * Not all animated image formats may be supported by every supported terminal
+         emulator
+       * Not all supported terminal emulators implement this feature of the protocol
+         e.g on Konsole, the first frame is drawn but the image is not animated
+
+    |
     """
 
     #: * ``x < 0``, JPEG encoding is disabled.


### PR DESCRIPTION
- Konsole no longer excluded.
  - It isn't my fault the feature isn't supported :/... and it could be supported in the future
- WEBP images are no longer excluded.
  - At least, wezterm now supports animated WebP. See:
  - https://github.com/wez/wezterm/issues/3250
  - https://github.com/wez/wezterm/issues/3258
  - https://github.com/wez/wezterm/issues/3260
- Exceptions are no longer raised in `draw()` for native animation.