### PR TITLE
Organize control sequences

### DIFF
--- a/src/term_image/ctlseqs.py
+++ b/src/term_image/ctlseqs.py
@@ -1,0 +1,140 @@
+"""
+..
+   Control Sequences
+
+   See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+"""
+
+from __future__ import annotations
+
+__all__ = []  # Updated later on
+
+import re
+from typing import Tuple
+
+# Parameters
+C = "%c"
+Ps = "%d"
+Pt = "%s"
+Pm = lambda n: ";".join((Ps,) * n)  # noqa: E731
+
+_START = None  # Marks the beginning control sequence definitions
+
+# C0
+BEL = "\x07"
+ESC = "\x1b"
+
+# C1
+APC = f"{ESC}_"
+CSI = f"{ESC}["
+DCS = f"{ESC}P"
+OSC = f"{ESC}]"
+ST = f"{ESC}\\"
+
+# Cursor Movement
+CURSOR_UP = f"{CSI}{Ps}A"
+CURSOR_DOWN = f"{CSI}{Ps}B"
+CURSOR_FORWARD = f"{CSI}{Ps}C"
+CURSOR_BACKWARD = f"{CSI}{Ps}D"
+
+# Select Graphic Rendition
+SGR_NORMAL = f"{CSI}m"
+SGR_FG_RGB = f"{CSI}38;2;{Pm(3)}m"
+SGR_FG_RGB_2 = f"{CSI}38:2::{Ps}:{Ps}:{Ps}m"
+SGR_BG_RGB = f"{CSI}48;2;{Pm(3)}m"
+SGR_BG_RGB_2 = f"{CSI}48:2::{Ps}:{Ps}:{Ps}m"
+
+# DEC Modes
+DECSET = f"{CSI}?{Ps}h"
+DECRST = f"{CSI}?{Ps}l"
+
+SHOW_CURSOR = DECSET % 25
+HIDE_CURSOR = DECRST % 25
+
+# # Terminal Synchronized Output
+# # See https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
+BEGIN_SYNCED_UPDATE = DECSET % 2026
+END_SYNCED_UPDATE = DECRST % 2026
+
+# Window manipulation (XTWINOPS)
+XTWINOPS_1 = f"{CSI}{Ps}t"
+
+TEXT_AREA_SIZE_PX = XTWINOPS_1 % 14
+CELL_SIZE_PX = XTWINOPS_1 % 16
+
+# Text parameters (OSC Ps ; Pt ST)
+TEXT_PARAM_SET = f"{OSC}{Ps};{Pt}{ST}"
+TEXT_PARAM_QUERY = f"{OSC}{Ps};?{ST}"
+
+TEXT_FG_QUERY = TEXT_PARAM_QUERY % 10
+TEXT_BG_QUERY = TEXT_PARAM_QUERY % 11
+
+# Others
+DA1 = f"{CSI}c"
+ERASE_CHARS = f"{CSI}{Ps}X"
+XTVERSION = f"{CSI}>q"
+
+# iTerm2 Inline Image Protocol
+# See https://iterm2.com/documentation-images.html
+ITERM2_START = f"{OSC}1337;File="
+
+# Kitty Graphics Protocol
+# See https://sw.kovidgoyal.net/kitty/graphics-protocol/
+KITTY_START = f"{APC}G"
+KITTY_TRANSMISSION = f"{KITTY_START}{Pt};{Pt}{ST}"
+KITTY_DELETE = KITTY_TRANSMISSION % (f"a=d,d={C}", "")
+KITTY_DELETE_EXTRA = KITTY_TRANSMISSION % (f"a=d,d={C},{Pt}", "")
+
+KITTY_SUPPORT_QUERY = KITTY_TRANSMISSION % (
+    "a=q,t=d,i=31,f=24,s=1,v=1,C=1,c=1,r=1",
+    "AAAA",
+)
+KITTY_END_CHUNKED = KITTY_TRANSMISSION % ("q=1,m=0", "")
+KITTY_DELETE_ALL = KITTY_DELETE % "A"
+KITTY_DELETE_CURSOR = KITTY_DELETE % "C"
+KITTY_DELETE_Z_INDEX = KITTY_DELETE_EXTRA % ("Z", f"z={Ps}")
+
+
+module_items = tuple(globals().items())
+for name, value in module_items[module_items.index(("_START", None)) + 1 :]:
+    globals()[f"{name}_b"] = value.encode()
+    __all__.extend((name, f"{name}_b"))
+
+
+# Patterns for responses to queries
+class Response:
+    CSI_escaped = re.escape(CSI)
+    OSC_escaped = re.escape(OSC)
+    ST_escaped = re.escape(ST)
+    ST_or_BEL = f"(?:{ST_escaped}|{BEL})"
+    XTWINOPS = rf"{CSI_escaped}{Ps};(\d+);(\d+)t"
+
+    RGB_SPEC_re = rf"{OSC_escaped}(\d+);rgb:([\da-fA-F/]+){ST_or_BEL}"
+    XTVERSION_re = rf"{DCS}>\|(\w+)[( ]([^){ESC}]+)\)?{ST_or_BEL}"
+    TEXT_AREA_SIZE_PX_re = XTWINOPS % 4
+    CELL_SIZE_PX_re = XTWINOPS % 6
+    KITTY_RESPONSE_re = (
+        f"{KITTY_START}"
+        r"i=(?P<id>\d+)(?:,I=(?P<number>\d+))?;(?P<message>.+?)"
+        f"{ST_escaped}"
+    )
+
+    for name, regex in tuple(locals().items()):
+        if name.endswith("_re"):
+            globals()[name] = re.compile(regex, re.ASCII)
+            __all__.append(name)
+
+
+__all__ += ("x_parse_color",)
+
+
+def x_parse_color(spec: str) -> Tuple[int, int, int]:
+    """Converts an RGB device specification according to ``XParseColor``
+
+    See the "Color Names" section of the ``XParseColor`` man page.
+    """
+    # One hex char -> 4 bits
+    return tuple(int(x, 16) * 255 // ((1 << (len(x) * 4)) - 1) for x in spec.split("/"))
+
+
+del _START, module_items, Response

--- a/src/term_image/image/block.py
+++ b/src/term_image/image/block.py
@@ -11,7 +11,8 @@ from typing import Optional, Tuple, Union
 
 import PIL
 
-from ..utils import BG_FMT, COLOR_RESET, FG_FMT, get_fg_bg_colors
+from ..ctlseqs import SGR_BG_RGB, SGR_FG_RGB, SGR_NORMAL
+from ..utils import get_fg_bg_colors
 from .common import TextImage
 
 warnings.filterwarnings("once", category=DeprecationWarning, module=__name__)
@@ -68,15 +69,15 @@ class BlockImage(TextImage):
             if alpha:
                 no_alpha = False
                 if a_cluster1 == 0 == a_cluster2:
-                    buf_write(COLOR_RESET)
+                    buf_write(SGR_NORMAL)
                     buf_write(blank * n)
                 elif a_cluster1 == 0:  # up is transparent
-                    buf_write(COLOR_RESET)
-                    buf_write(FG_FMT % cluster2)
+                    buf_write(SGR_NORMAL)
+                    buf_write(SGR_FG_RGB % cluster2)
                     buf_write(lower_pixel * n)
                 elif a_cluster2 == 0:  # down is transparent
-                    buf_write(COLOR_RESET)
-                    buf_write(FG_FMT % cluster1)
+                    buf_write(SGR_NORMAL)
+                    buf_write(SGR_FG_RGB % cluster1)
                     buf_write(upper_pixel * n)
                 else:
                     no_alpha = True
@@ -86,11 +87,11 @@ class BlockImage(TextImage):
                 # Kitty does not render BG colors equal to the default BG color
                 if is_on_kitty and cluster2 == bg_color:
                     r += r < 255 or -1
-                buf_write(BG_FMT % (r, g, b))
+                buf_write(SGR_BG_RGB % (r, g, b))
                 if cluster1 == cluster2:
                     buf_write(blank * n)
                 else:
-                    buf_write(FG_FMT % cluster1)
+                    buf_write(SGR_FG_RGB % cluster1)
                     buf_write(upper_pixel * n)
 
         buffer = io.StringIO()
@@ -106,7 +107,7 @@ class BlockImage(TextImage):
             blank = " "
             lower_pixel = LOWER_PIXEL
             upper_pixel = UPPER_PIXEL
-        end_of_line = COLOR_RESET + "\n"
+        end_of_line = SGR_NORMAL + "\n"
 
         width, height = self._get_render_size()
         frame_img = img if frame else None
@@ -171,7 +172,7 @@ class BlockImage(TextImage):
             if row_no < height:  # last line not yet rendered
                 buf_write(end_of_line)
 
-        buf_write(COLOR_RESET)  # Reset color after last line
+        buf_write(SGR_NORMAL)  # Reset color after last line
 
         with buffer:
             return buffer.getvalue()

--- a/src/term_image/widget/urwid.py
+++ b/src/term_image/widget/urwid.py
@@ -8,16 +8,13 @@ from typing import Optional, Tuple
 
 import urwid
 
+from .. import ctlseqs
+
+# These sequences are used during performance-critical operations that occur often
+from ..ctlseqs import BEGIN_SYNCED_UPDATE, END_SYNCED_UPDATE, ESC_b, SGR_NORMAL_b
 from ..exceptions import UrwidImageError
-from ..image import BaseImage, ITerm2Image, KittyImage, Size, TextImage, kitty
-from ..utils import (
-    BEGIN_SYNCED_UPDATE,
-    END_SYNCED_UPDATE,
-    COLOR_RESET_b,
-    ESC_b,
-    lock_tty,
-    write_tty,
-)
+from ..image import BaseImage, ITerm2Image, KittyImage, Size, TextImage
+from ..utils import lock_tty, write_tty
 
 # NOTE: Any new "private" attribute of any subclass of an urwid class should be
 # prepended with "_ti" to prevent clashes with names used by urwid itself.
@@ -352,7 +349,7 @@ class UrwidImageCanvas(urwid.Canvas):
                     ((None, "U", b" " * new_pad_right),) if new_pad_right else ()
                 )
                 color_reset = (
-                    ((None, "U", COLOR_RESET_b),)
+                    ((None, "U", SGR_NORMAL_b),)
                     if image_size[0] > trim_image_right > 0
                     else ()
                 )
@@ -537,9 +534,9 @@ class UrwidImageScreen(urwid.raw_display.Screen):
         # Also takes care of iterm2 images on Konsole
         if KittyImage._forced_support or KittyImage.is_supported():
             if now:
-                write_tty(kitty.DELETE_ALL_IMAGES_b)
+                write_tty(ctlseqs.KITTY_DELETE_ALL_b)
             else:
-                self.write(kitty.DELETE_ALL_IMAGES)
+                self.write(ctlseqs.KITTY_DELETE_ALL)
             UrwidImageCanvas._ti_change_disguise()
 
     # `@lock_tty` prevents queries during a synced update.

--- a/tests/test_image/common.py
+++ b/tests/test_image/common.py
@@ -8,8 +8,9 @@ import pytest
 from PIL import Image
 
 from term_image import exceptions, set_cell_ratio
+from term_image.ctlseqs import SGR_BG_RGB, SGR_NORMAL
 from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, Size, TextImage
-from term_image.utils import BG_FMT, COLOR_RESET, get_fg_bg_colors, get_terminal_size
+from term_image.utils import get_fg_bg_colors, get_terminal_size
 
 from .. import (
     reset_cell_size_ratio,
@@ -514,11 +515,11 @@ class TestRender_Text:
             bg = bg or (0, 0, 0)
 
             assert all(
-                line == BG_FMT % bg + " " * self.trans.width + COLOR_RESET
+                line == SGR_BG_RGB % bg + " " * self.trans.width + SGR_NORMAL
                 for line in self.render_image("#").splitlines()
             )
             assert all(
-                line == BG_FMT % bg + " " * self.trans.width + COLOR_RESET
+                line == SGR_BG_RGB % bg + " " * self.trans.width + SGR_NORMAL
                 for line in self.render_image(bg_hex).splitlines()
             )
 
@@ -526,11 +527,11 @@ class TestRender_Text:
             bg = (r, *bg[1:])
 
             assert all(
-                line == BG_FMT % bg + " " * self.trans.width + COLOR_RESET
+                line == SGR_BG_RGB % bg + " " * self.trans.width + SGR_NORMAL
                 for line in self.render_image("#").splitlines()
             )
             assert all(
-                line == BG_FMT % bg + " " * self.trans.width + COLOR_RESET
+                line == SGR_BG_RGB % bg + " " * self.trans.width + SGR_NORMAL
                 for line in self.render_image(bg_hex).splitlines()
             )
 
@@ -549,7 +550,7 @@ class TestRender_Text:
         for split_line, no_split_line in zip(
             render_split.splitlines(), render_no_split.splitlines()
         ):
-            cells = split_line.strip(COLOR_RESET).split("\0")
+            cells = split_line.strip(SGR_NORMAL).split("\0")
 
             assert "".join(split_line.split("\0")) == no_split_line
             assert len(cells) == _size

--- a/tests/test_image/test_base.py
+++ b/tests/test_image/test_base.py
@@ -12,10 +12,10 @@ import pytest
 from PIL import Image, UnidentifiedImageError
 
 from term_image import set_cell_ratio
+from term_image.ctlseqs import ESC
 from term_image.exceptions import InvalidSizeError, TermImageError
 from term_image.image import BaseImage, BlockImage, ImageIterator, ImageSource, Size
 from term_image.image.common import _ALPHA_THRESHOLD
-from term_image.utils import ESC
 
 from .common import _size, columns, lines, python_img, setup_common
 

--- a/tests/test_image/test_block.py
+++ b/tests/test_image/test_block.py
@@ -2,9 +2,9 @@
 
 from random import random
 
+from term_image.ctlseqs import SGR_BG_RGB, SGR_NORMAL
 from term_image.image import BlockImage
 from term_image.image.common import _ALPHA_THRESHOLD
-from term_image.utils import BG_FMT, COLOR_RESET, CSI
 
 from .. import set_fg_bg_colors
 from . import common
@@ -43,14 +43,14 @@ class TestRender:
         render = self.render_image(_ALPHA_THRESHOLD)
         assert render == str(self.trans) == f"{self.trans:1.1}"
         assert all(
-            line == COLOR_RESET + " " * self.trans.width + COLOR_RESET
+            line == SGR_NORMAL + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
         # Transparency disabled
         render = self.render_image(None)
         assert render == f"{self.trans:1.1#}"
         assert all(
-            line == f"{CSI}48;2;0;0;0m" + " " * self.trans.width + COLOR_RESET
+            line == SGR_BG_RGB % (0, 0, 0) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
 
@@ -64,7 +64,7 @@ class TestRender:
             render = self.render_image("#")
             assert render == f"{self.trans:1.1##}"
             assert all(
-                line == BG_FMT % bg + " " * self.trans.width + COLOR_RESET
+                line == SGR_BG_RGB % bg + " " * self.trans.width + SGR_NORMAL
                 for line in render.splitlines()
             )
         set_fg_bg_colors((0, 0, 0), (0, 0, 0))
@@ -72,28 +72,28 @@ class TestRender:
         render = self.render_image("#ff0000")
         assert render == f"{self.trans:1.1#ff0000}"
         assert all(
-            line == f"{CSI}48;2;255;0;0m" + " " * self.trans.width + COLOR_RESET
+            line == SGR_BG_RGB % (255, 0, 0) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
         # green
         render = self.render_image("#00ff00")
         assert render == f"{self.trans:1.1#00ff00}"
         assert all(
-            line == f"{CSI}48;2;0;255;0m" + " " * self.trans.width + COLOR_RESET
+            line == SGR_BG_RGB % (0, 255, 0) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
         # blue
         render = self.render_image("#0000ff")
         assert render == f"{self.trans:1.1#0000ff}"
         assert all(
-            line == f"{CSI}48;2;0;0;255m" + " " * self.trans.width + COLOR_RESET
+            line == SGR_BG_RGB % (0, 0, 255) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
         # white
         render = self.render_image("#ffffff")
         assert render == f"{self.trans:1.1#ffffff}"
         assert all(
-            line == f"{CSI}48;2;255;255;255m" + " " * self.trans.width + COLOR_RESET
+            line == SGR_BG_RGB % (255, 255, 255) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
 
@@ -103,7 +103,7 @@ class TestRender:
             render = self.render_image(_ALPHA_THRESHOLD)
             assert render.count("\n") + 1 == self.trans.rendered_height
             assert all(
-                line == COLOR_RESET + " " * self.trans.rendered_width + COLOR_RESET
+                line == SGR_NORMAL + " " * self.trans.rendered_width + SGR_NORMAL
                 for line in render.splitlines()
             )
 
@@ -118,6 +118,6 @@ class TestRender:
             render = self.render_image(_ALPHA_THRESHOLD)
             assert render.count("\n") + 1 == self.trans.rendered_height
             assert all(
-                line == COLOR_RESET + " " * self.trans.rendered_width + COLOR_RESET
+                line == SGR_NORMAL + " " * self.trans.rendered_width + SGR_NORMAL
                 for line in render.splitlines()
             )

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -4,9 +4,9 @@ from types import GeneratorType
 import pytest
 from PIL import Image
 
+from term_image.ctlseqs import SGR_NORMAL
 from term_image.exceptions import TermImageError
 from term_image.image import BlockImage, ImageIterator, Size
-from term_image.utils import COLOR_RESET
 
 _size = (30, 15)
 
@@ -257,13 +257,13 @@ def test_formatting():
     image_it = ImageIterator(gif_image, 1, "1.1")
     assert next(image_it).count("\n") + 1 == _size[1]
     # First line without escape codes
-    assert next(image_it).partition("\n")[0].strip(COLOR_RESET) == " " * _size[0]
+    assert next(image_it).partition("\n")[0].strip(SGR_NORMAL) == " " * _size[0]
 
     # Transparency disabled, not padded
     image_it = ImageIterator(gif_image, 1, "1.1#")
     assert next(image_it).count("\n") + 1 == _size[1]
     # First line without escape codes
-    assert next(image_it).partition("\n")[0].strip(COLOR_RESET) != " " * _size[0]
+    assert next(image_it).partition("\n")[0].strip(SGR_NORMAL) != " " * _size[0]
 
     # Transparency disabled, padded
     image_it = ImageIterator(gif_image, 1, f"{_size[0] + 2}.{_size[1] + 2}#")


### PR DESCRIPTION
- Adds `term_image.ctlseqs` submodule.
- Defines all control sequences used across the library in `.ctlseqs`.
- Changes all parts of the library and test suite to import from `.ctlseqs`.