### PR TITLE
Improve utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `UrwidImageScreen.clear()` also clears images ([ed3baa3]).
+- `term_image.utils.get_cell_size()` to the public API ([#87]).
 
 ### Changed
 - `UrwidImage.clear_all()` -> `UrwidImageScreen.clear_images()` ([08f4e4d]).
 - `KeyboardInterrupt` is no longer raised when `SIGINT` is used to end an animation ([fa47742]).
 - Switched to the standard SGR FG/BG direct color control sequences ([b38e2e8]).
+- Improved terminal cell size computation ([#87]).
 
+[#87]: https://github.com/AnonymouX47/term-image/pull/87
 [08f4e4d]: https://github.com/AnonymouX47/term-image/commit/08f4e4d1514313bbd4278dadde46d21d0b11ed1f
 [fa47742]: https://github.com/AnonymouX47/term-image/commit/fa477424c83474256d4972c4b2cdd4a765bc1cda
 [ed3baa3]: https://github.com/AnonymouX47/term-image/commit/ed3baa38d7621720c007f4662f89d7abadd76ec3

--- a/src/term_image/__init__.py
+++ b/src/term_image/__init__.py
@@ -27,7 +27,6 @@ from typing import Optional, Union
 
 from . import utils
 from .exceptions import TermImageError
-from .utils import get_cell_size
 
 version_info = (0, 7, 0, "dev")
 
@@ -121,7 +120,7 @@ def get_cell_ratio() -> float:
     See :py:func:`set_cell_ratio`.
     """
     # `(1, 2)` is a fallback in case the terminal doesn't respond in time
-    return _cell_ratio or truediv(*(get_cell_size() or (1, 2)))
+    return _cell_ratio or truediv(*(utils.get_cell_size() or (1, 2)))
 
 
 def set_cell_ratio(ratio: Union[float, AutoCellRatio]) -> None:
@@ -161,7 +160,7 @@ def set_cell_ratio(ratio: Union[float, AutoCellRatio]) -> None:
 
     if isinstance(ratio, AutoCellRatio):
         if AutoCellRatio.is_supported is None:
-            AutoCellRatio.is_supported = get_cell_size() is not None
+            AutoCellRatio.is_supported = utils.get_cell_size() is not None
 
         if not AutoCellRatio.is_supported:
             raise TermImageError(
@@ -170,7 +169,7 @@ def set_cell_ratio(ratio: Union[float, AutoCellRatio]) -> None:
             )
         elif ratio is AutoCellRatio.FIXED:
             # `(1, 2)` is a fallback in case the terminal doesn't respond in time
-            _cell_ratio = truediv(*(get_cell_size() or (1, 2)))
+            _cell_ratio = truediv(*(utils.get_cell_size() or (1, 2)))
         else:
             _cell_ratio = None
     elif isinstance(ratio, float):

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -1039,7 +1039,7 @@ class BaseImage(metaclass=ImageMeta):
             self._seek_position = pos
 
     @ClassInstanceMethod
-    def set_render_method(self_or_cls, method: Optional[str] = None) -> None:
+    def set_render_method(cls, method: Optional[str] = None) -> None:
         """Sets the :term:`render method` used by instances of a :term:`render style`
         class that implements multiple render methods.
 
@@ -1079,23 +1079,33 @@ class BaseImage(metaclass=ImageMeta):
             raise TypeError(
                 f"'method' must be a string or `None` (got: {type(method).__name__!r})"
             )
-
-        if method is not None and method.lower() not in self_or_cls._render_methods:
-            cls = (
-                type(self_or_cls) if isinstance(self_or_cls, __class__) else self_or_cls
-            )
+        if method is not None and method.lower() not in cls._render_methods:
             raise ValueError(f"Unknown render method {method!r} for {cls.__name__}")
 
         if not method:
-            if isinstance(self_or_cls, __class__):
-                try:
-                    del self_or_cls._render_method
-                except AttributeError:
-                    pass
-            elif self_or_cls._render_methods:
-                self_or_cls._render_method = self_or_cls._default_render_method
+            if cls._render_methods:
+                cls._render_method = cls._default_render_method
         else:
-            self_or_cls._render_method = method
+            cls._render_method = method
+
+    @set_render_method.instancemethod
+    def set_render_method(self, method: Optional[str] = None) -> None:
+        if method is not None and not isinstance(method, str):
+            raise TypeError(
+                f"'method' must be a string or `None` (got: {type(method).__name__!r})"
+            )
+        if method is not None and method.lower() not in type(self)._render_methods:
+            raise ValueError(
+                f"Unknown render method {method!r} for {type(self).__name__}"
+            )
+
+        if not method:
+            try:
+                del self._render_method
+            except AttributeError:
+                pass
+        else:
+            self._render_method = method
 
     def set_size(
         self,

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -330,6 +330,10 @@ class ITerm2Image(GraphicsImage):
         except AttributeError:
             pass
 
+    jpeg_quality = jpeg_quality.cls_getter(jpeg_quality.fget)
+    jpeg_quality = jpeg_quality.cls_setter(jpeg_quality.fset)
+    jpeg_quality = jpeg_quality.cls_deleter(jpeg_quality.fdel)
+
     native_anim_max_bytes = ClassProperty(
         # 2 MiB default
         lambda cls: getattr(__class__, "_native_anim_max_bytes", 2 * 2**20),
@@ -446,6 +450,10 @@ class ITerm2Image(GraphicsImage):
             del self_or_cls._read_from_file
         except AttributeError:
             pass
+
+    read_from_file = read_from_file.cls_getter(read_from_file.fget)
+    read_from_file = read_from_file.cls_setter(read_from_file.fset)
+    read_from_file = read_from_file.cls_deleter(read_from_file.fdel)
 
     @classmethod
     def clear(cls, cursor: bool = False, now: bool = False) -> None:

--- a/src/term_image/image/kitty.py
+++ b/src/term_image/image/kitty.py
@@ -309,9 +309,7 @@ class KittyImage(GraphicsImage):
             # Not supported if it doesn't respond to either query
             # or responds to the second but not the first
             if response:
-                response = ctlseqs.KITTY_RESPONSE_re.match(
-                    response.rpartition(ctlseqs.ESC_b)[0].decode()
-                )
+                response = ctlseqs.KITTY_RESPONSE_re.match(response.decode())
             if response and response["id"] == "31" and response["message"] == "OK":
                 name, version = get_terminal_name_version()
                 # Only kitty >= 0.20.0 implement the protocol features utilized

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -456,9 +456,7 @@ def get_fg_bg_colors(
 
     fg = bg = None
     if response:
-        for c, spec in ctlseqs.RGB_SPEC_re.findall(
-            response.decode().rpartition(ctlseqs.ESC)[0]
-        ):
+        for c, spec in ctlseqs.RGB_SPEC_re.findall(response.decode()):
             if c == "10":
                 fg = ctlseqs.x_parse_color(spec)
             elif c == "11":
@@ -490,9 +488,7 @@ def get_terminal_name_version() -> Tuple[Optional[str], Optional[str]]:
         if _queries_enabled:
             read_tty()  # The rest of the response to DA1
 
-    match = response and ctlseqs.XTVERSION_re.fullmatch(
-        response.decode().rpartition(ctlseqs.ESC)[0]
-    )
+    match = response and ctlseqs.XTVERSION_re.match(response.decode())
     name, version = (
         match.groups()
         if match

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -53,10 +53,24 @@ class ClassInstanceMethod(classmethod):
     and when invoked via an instance, behaves like an instance method.
     """
 
+    def __init__(
+        self, f_owner: FunctionType, f_instance: Optional[FunctionType] = None
+    ):
+        super().__init__(f_owner)
+        self.f_owner = f_owner
+        self.f_instance = f_instance
+
     def __get__(self, instance, owner=None):
-        # classmethod just uses `owner` directly if given.
-        # Otherwise, type(instance) but we're not concerned with this.
-        return super().__get__(None, instance or owner)
+        if instance:
+            return self.f_instance.__get__(instance, owner)
+        else:
+            return super().__get__(instance, owner)
+
+    def classmethod(self, function: FunctionType) -> ClassInstanceMethod:
+        return type(self)(function, self.f_instance)
+
+    def instancemethod(self, function: FunctionType) -> ClassInstanceMethod:
+        return type(self)(self.f_owner, function)
 
 
 class ClassPropertyBase(property):

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -24,7 +24,7 @@ from queue import Empty, Queue
 from shutil import get_terminal_size as _get_terminal_size
 from threading import RLock
 from time import monotonic
-from types import FunctionType
+from types import FunctionType, MappingProxyType
 from typing import Callable, Optional, Tuple, Union
 
 from . import ctlseqs
@@ -132,7 +132,7 @@ class ClassPropertyMeta(type):
     its instances.
 
     - Takes care of inherited class properties.
-    - Works with both cooperative multiple ane multi-level inheritance.
+    - Works with both cooperative multiple and multi-level inheritance.
 
     SEE ALSO:
         :py:class:`ClassPropertyBase`
@@ -144,7 +144,10 @@ class ClassPropertyMeta(type):
             if isinstance(base, __class__):
                 class_properties.update(base._class_properties_)
 
-        return super().__new__(cls, name, bases, dict, **kwds)
+        self = super().__new__(cls, name, bases, dict, **kwds)
+        self._class_properties_ = MappingProxyType(class_properties)
+
+        return self
 
     def __setattr__(self, name, value):
         class_property = self._class_properties_.get(name)

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 __all__ = (
+    "get_cell_size",
     "get_terminal_name_version",
     "get_terminal_size",
     "lock_tty",

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -93,7 +93,7 @@ class ClassPropertyBase(property):
         super().__init__(fget, fset, fdel, doc)
         # `property` doesn't set `__doc__`, probably cos this class' `__doc__`
         # attribute overrides its `__doc__` descriptor.
-        super().__setattr__("__doc__", doc)
+        super().__setattr__("__doc__", doc or fget.__doc__)
 
     def __set_name__(self, owner, name):
         self.__objclass__ = owner


### PR DESCRIPTION
- Renames `_tty` -> `_tty_fd` in `.utils`
- Improves cell size computation
  - Use response to `CSI 16 t` when supported, instead of `CSI 14 t`
- Makes `.utils.get_cell_size()` public
- Improves `.utils.ClassInstanceMethod`, `.utils.ClassInstanceProperty` and `.utils.ClassPropertyMeta`
- Code cleanup