### PR TITLE
Remove image scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **(BREAKING!)** `InvalidSizeError` no longer inherits from `ValueError` ([26ea969]).
 - **(BREAKING!)** `UrwidImage` now raises `UrwidImageError` instead of `ValueError` when rendered as a fixed widget ([a612b59]).
 
+### Removed
+- Image scaling ([#88]).
+  - *scale* parameter of `BaseImage`, `BaseImage.from_file()`, `BaseImage.from_url()`, etc.
+  - `scale`, `scale_x` and `scale_y` properties of `BaseImage`.
+
 [#87]: https://github.com/AnonymouX47/term-image/pull/87
+[#88]: https://github.com/AnonymouX47/term-image/pull/88
 [08f4e4d]: https://github.com/AnonymouX47/term-image/commit/08f4e4d1514313bbd4278dadde46d21d0b11ed1f
 [fa47742]: https://github.com/AnonymouX47/term-image/commit/fa477424c83474256d4972c4b2cdd4a765bc1cda
 [ed3baa3]: https://github.com/AnonymouX47/term-image/commit/ed3baa38d7621720c007f4662f89d7abadd76ec3

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -135,11 +135,6 @@ Below are definitions of terms used across the API, exception messages and the d
 
       .. seealso:: :ref:`render-styles`
 
-   scale
-      The fraction/ratio of an image's size that'll actually be used to :term:`render` it.
-      
-      .. seealso:: :ref:`image-scale`
-
    manual size
    manual sizing
       A form of sizing wherein **both** the width and the height are specified to set the image size.

--- a/docs/source/start/tutorial.rst
+++ b/docs/source/start/tutorial.rst
@@ -80,12 +80,15 @@ The output (using :py:func:`print`) should look like:
 Formatted Rendering
 ^^^^^^^^^^^^^^^^^^^
 .. note::
-   To see the effect of :term:`alignment` in the steps below, please scale the image down using::
+   To see the effect of :term:`alignment` in the steps below, set the image size
+   **smaller** than **your** terminal size, with e.g::
 
-     image.scale = 0.75
+     image.height = 50
 
-   This simply sets the x-axis and y-axis :term:`scale` of the image to ``0.75``.
-   We'll see more about this :ref:`later <image-scale>`.
+   This sets the image height to ``50`` lines (which is less than ``70``, the height of
+   the terminal window used to prepare this tutorial) and the width proportionally.
+
+   We'll see more about this later.
 
 Below are examples of formatted rendering:
 
@@ -176,14 +179,14 @@ There are two basic ways to draw an image to the terminal screen:
      terminal, while the latter doesn't.
 
 
-.. important:: All the examples above use :term:`dynamic <dynamic size>`,
-   :term:`automatic <automatic size>` sizing and default :term:`scale`.
+.. important:: All the examples **above** use :term:`dynamic <dynamic size>` and
+   :term:`automatic <automatic size>` sizing.
 
 
 Image Size
 ----------
 
-| The size of an image is the **unscaled** dimension with which an image is rendered.
+| The size of an image determines the dimension of its render output.
 | The image size can be retrieved via the :py:attr:`~term_image.image.BaseImage.size`,
   :py:attr:`~term_image.image.BaseImage.width` and :py:attr:`~term_image.image.BaseImage.height` properties.
 
@@ -315,57 +318,7 @@ True
    See :py:meth:`~term_image.image.BaseImage.set_size` for extended sizing control.
 
 
-.. _image-scale:
-
-Image scale
------------
-
-| The scale of an image is the **ratio** of its size with which it will actually be rendered.
-| A valid scale value is a :py:class:`float` in the range ``0.0`` < ``x`` <= ``1.0``
-  i.e greater than zero and less than or equal to one.
-
-The image scale can be retrieved via the properties :py:attr:`~term_image.image.BaseImage.scale`,
-:py:attr:`~term_image.image.BaseImage.scale_x` and :py:attr:`~term_image.image.BaseImage.scale_y`.
-
-The scale can be set at instantiation by passing a value to the *scale* **keyword-only** paramter.
-
->>> image = from_file("python.png", scale=(0.75, 0.6))
->>> image.scale
->>> (0.75, 0.6)
-
-The drawn image (using ``image.draw()``) should look like:
-
-.. image:: /resources/tutorial/scale_set.png
-
-If the *scale* argument is ommited, the default scale ``(1.0, 1.0)`` is used.
-
->>> image = from_file("python.png")
->>> image.scale
->>> (1.0, 1.0)
-
-The drawn image (using ``image.draw()``) should look like:
-
-.. image:: /resources/tutorial/scale_unset.png
-
-| The properties :py:attr:`~term_image.image.BaseImage.scale`, :py:attr:`~term_image.image.BaseImage.scale_x` and :py:attr:`~term_image.image.BaseImage.scale_y` are used to set the scale of an image after instantiation.
-
-| ``scale`` accepts a tuple of two scale values or a single scale value.
-| ``scale_x`` and ``scale_y`` each accept a single scale value.
-
->>> image = from_file("python.png")
->>> image.scale = (.3, .56756)
->>> image.scale
-(0.3, 0.56756)
->>> image.scale = .5
->>> image.scale
-(0.5, 0.5)
->>> image.scale_x = .75
->>> image.scale
-(0.75, 0.5)
->>> image.scale_y = 1.
->>> image.scale
-(0.75, 1.0)
-
 |
 
-Finally, to explore more of the library's features and functionality, check out the :doc:`/guide/index` and the :doc:`/reference/index`.
+To explore more of the library's features and functionality, check out the
+:doc:`/guide/index` and the :doc:`/reference/index`.

--- a/src/term_image/image/__init__.py
+++ b/src/term_image/image/__init__.py
@@ -71,7 +71,7 @@ def AutoImage(
 
 def from_file(
     filepath: Union[str, os.PathLike],
-    **kwargs: Union[None, int, Tuple[float, float]],
+    **kwargs: Union[None, int],
 ) -> BaseImage:
     """Creates an image instance from an image file.
 
@@ -86,7 +86,7 @@ def from_file(
 
 def from_url(
     url: str,
-    **kwargs: Union[None, int, Tuple[float, float]],
+    **kwargs: Union[None, int],
 ) -> BaseImage:
     """Creates an image instance from an image URL.
 

--- a/src/term_image/image/__init__.py
+++ b/src/term_image/image/__init__.py
@@ -22,7 +22,7 @@ __all__ = (
 )
 
 import os
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import PIL
 
@@ -57,7 +57,6 @@ def AutoImage(
     *,
     width: Optional[int] = None,
     height: Optional[int] = None,
-    scale: Tuple[float, float] = (1.0, 1.0),
 ) -> BaseImage:
     """Creates an image instance from a PIL image instance.
 
@@ -67,7 +66,7 @@ def AutoImage(
 
     Same arguments and raised exceptions as the :py:class:`BaseImage` class constructor.
     """
-    return auto_image_class()(image, width=width, height=height, scale=scale)
+    return auto_image_class()(image, width=width, height=height)
 
 
 def from_file(

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -843,7 +843,7 @@ class BaseImage(metaclass=ImageMeta):
     def from_file(
         cls,
         filepath: Union[str, os.PathLike],
-        **kwargs: Union[None, int, Tuple[float, float]],
+        **kwargs: Union[None, int],
     ) -> BaseImage:
         """Creates an instance from an image file.
 
@@ -891,7 +891,7 @@ class BaseImage(metaclass=ImageMeta):
     def from_url(
         cls,
         url: str,
-        **kwargs: Union[None, int, Tuple[float, float]],
+        **kwargs: Union[None, int],
     ) -> BaseImage:
         """Creates an instance from an image URL.
 

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -230,8 +230,6 @@ class BaseImage(metaclass=ImageMeta):
           * an integer; vertical dimension of the image, in lines.
           * a :py:class:`~term_image.image.Size` enum member.
 
-        scale: The fraction of the size (on respective axes) to render the image with.
-
     Raises:
         TypeError: An argument is of an inappropriate type.
         ValueError: An argument is of an appropriate type but has an
@@ -243,8 +241,6 @@ class BaseImage(metaclass=ImageMeta):
     NOTE:
         * If neither *width* nor *height* is given (or both are ``None``),
           :py:attr:`~term_image.image.Size.FIT` applies.
-        * The image size is multiplied by the :term:`scale` on respective axes when
-          the image is :term:`rendered`.
         * For animated images, the seek position is initialized to the current seek
           position of the given image.
         * It's allowed to set properties for :term:`animated` images on non-animated
@@ -273,7 +269,6 @@ class BaseImage(metaclass=ImageMeta):
         *,
         width: Union[int, Size, None] = None,
         height: Union[int, Size, None] = None,
-        scale: Tuple[float, float] = (1.0, 1.0),
     ) -> None:
         """See the class description"""
         if not isinstance(image, Image.Image):
@@ -289,8 +284,6 @@ class BaseImage(metaclass=ImageMeta):
             self.size = Size.FIT
         else:
             self.set_size(width, height)
-        self._scale = []
-        self._scale[:] = self._check_scale(scale)
 
         self._is_animated = hasattr(image, "is_animated") and image.is_animated
         if self._is_animated:
@@ -327,7 +320,7 @@ class BaseImage(metaclass=ImageMeta):
         return ImageIterator(self, 1, "1.1", False)
 
     def __repr__(self) -> str:
-        return "<{}: source_type={} size={} scale={} is_animated={}>".format(
+        return "<{}: source_type={} size={} is_animated={}>".format(
             type(self).__name__,
             self._source_type.name,
             (
@@ -335,7 +328,6 @@ class BaseImage(metaclass=ImageMeta):
                 if isinstance(self._size, Size)
                 else "x".join(map(str, self._size))
             ),
-            "x".join(format(x, ".2") for x in self._scale),
             self._is_animated,
         )
 
@@ -426,7 +418,7 @@ class BaseImage(metaclass=ImageMeta):
         lambda self: self._size if isinstance(self._size, Size) else self._size[1],
         lambda self, height: self.set_size(height=height),
         doc="""
-        The **unscaled** height of the image
+        Image height
 
         :type: Union[Size, int]
 
@@ -501,155 +493,59 @@ class BaseImage(metaclass=ImageMeta):
         return self._n_frames
 
     rendered_height = property(
-        lambda self: round(
-            (
-                self._valid_size(None, self._size)
-                if isinstance(self._size, Size)
-                else self._size
-            )[1]
-            * self._scale[1]
-        )
-        or 1,
+        lambda self: (
+            self._valid_size(None, self._size)
+            if isinstance(self._size, Size)
+            else self._size
+        )[1],
         doc="""
-        The **scaled** height of the image
+        The height with which the image is :term:`rendered`
 
         :type: int
 
         GET:
-            Returns the actual number of lines that the image will occupy when drawn
-            in a terminal.
+            Returns the number of lines the image will occupy when drawn in a terminal.
         """,
     )
 
     rendered_size = property(
-        lambda self: tuple(
-            map(
-                lambda x: x or 1,
-                map(
-                    round,
-                    map(
-                        mul,
-                        (
-                            self._valid_size(self._size, None)
-                            if isinstance(self._size, Size)
-                            else self._size
-                        ),
-                        self._scale,
-                    ),
-                ),
-            )
+        lambda self: (
+            self._valid_size(self._size, None)
+            if isinstance(self._size, Size)
+            else self._size
         ),
         doc="""
-        The **scaled** size of the image
+        The size with which the image is :term:`rendered`
 
         :type: Tuple[int, int]
 
         GET:
-            Returns the actual number of columns and lines (respectively) that the
-            image will occupy when drawn in a terminal.
+            Returns the number of columns and lines (respectively) the image will
+            occupy when drawn in a terminal.
         """,
     )
 
     rendered_width = property(
-        lambda self: round(
-            (
-                self._valid_size(self._size, None)
-                if isinstance(self._size, Size)
-                else self._size
-            )[0]
-            * self._scale[0]
-        )
-        or 1,
+        lambda self: (
+            self._valid_size(self._size, None)
+            if isinstance(self._size, Size)
+            else self._size
+        )[0],
         doc="""
-        The **scaled** width of the image
+        The width with which the image is :term:`rendered`
 
         :type: int
 
         GET:
-            Returns the actual number of columns that the image will occupy when drawn
-            in a terminal.
+            Returns the number of columns the image will occupy when drawn in a
+            terminal.
         """,
     )
-
-    scale = property(
-        lambda self: tuple(self._scale),
-        doc="""
-        Image :term:`scale`
-
-        :type: Tuple[float, float]
-
-        GET:
-            Returns the scale of the image on the horizontal and vertical axes
-            respectively.
-
-        SET:
-            If set to:
-
-            * A *scale value*; sets the scale on both axes.
-            * A :py:class:`tuple` of two *scale values*; sets the scale on the
-              ``(horizontal, vertical)`` axes respectively.
-
-        A scale value is a :py:class:`float` in the range **0.0 < scale <= 1.0**.
-        """,
-    )
-
-    @scale.setter
-    def scale(self, scale: Union[float, Tuple[float, float]]) -> None:
-        if isinstance(scale, float):
-            if not 0.0 < scale <= 1.0:
-                raise arg_value_error_range("scale", scale)
-            self._scale[:] = (scale,) * 2
-        elif isinstance(scale, tuple):
-            self._scale[:] = self._check_scale(scale)
-        else:
-            raise arg_type_error("scale", scale)
-
-    scale_x = property(
-        lambda self: self._scale[0],
-        doc="""
-        Horizontal :term:`scale`
-
-        :type: float
-
-        GET:
-            Returns the scale of the image on the horizontal axis.
-
-        SET:
-            Sets the scale of the image on the horizontal axis.
-
-        A scale value is a :py:class:`float` in the range **0.0 < scale <= 1.0**.
-        """,
-    )
-
-    @scale_x.setter
-    def scale_x(self, x: float) -> None:
-        self._scale[0] = self._check_scale_2(x)
-
-    scale_y = property(
-        lambda self: self._scale[1],
-        doc="""
-        Vertical :term:`scale`
-
-        :type: float
-
-        GET:
-            Returns the scale of the image on the vertical axis.
-
-        SET:
-            Sets the scale of the image on the vertical axis.
-
-        A scale value is a :py:class:`float` in the range **0.0 < scale <= 1.0**.
-        """,
-    )
-
-    @scale_y.setter
-    def scale_y(self, y: float) -> None:
-        self._scale[1] = self._check_scale_2(y)
 
     size = property(
         lambda self: self._size,
         doc="""
-        The **unscaled** size of the image
+        Image size
 
         :type: Union[Size, Tuple[int, int]]
 
@@ -712,7 +608,7 @@ class BaseImage(metaclass=ImageMeta):
         lambda self: self._size if isinstance(self._size, Size) else self._size[0],
         lambda self, width: self.set_size(width),
         doc="""
-        The **unscaled** width of the image
+        Image width
 
         :type: Union[Size, int]
 
@@ -1354,41 +1250,6 @@ class BaseImage(metaclass=ImageMeta):
 
         return h_align, width, v_align, height
 
-    @staticmethod
-    def _check_scale(scale: Tuple[float, float]) -> Tuple[float, float]:
-        """Checks a tuple of scale values.
-
-        Returns:
-            The tuple of scale values, if valid.
-
-        Raises:
-            TypeError: The object is not a tuple of ``float``\\ s.
-            ValueError: The object is not a 2-tuple or the values are out of range.
-        """
-        if not (isinstance(scale, tuple) and all(isinstance(x, float) for x in scale)):
-            raise arg_type_error("scale", scale)
-
-        if not (len(scale) == 2 and all(0.0 < x <= 1.0 for x in scale)):
-            raise arg_value_error("scale", scale)
-        return scale
-
-    @staticmethod
-    def _check_scale_2(scale: float) -> float:
-        """Checks a single scale value.
-
-        Returns:
-            The scale value, if valid.
-
-        Raises:
-            TypeError: The object is not a ``float``.
-            ValueError: The value is out of range.
-        """
-        if not isinstance(scale, float):
-            raise arg_type_error("scale", scale)
-        if not 0.0 < scale <= 1.0:
-            raise arg_value_error_range("scale", scale)
-        return scale
-
     @classmethod
     def _check_style_args(cls, style_args: Dict[str, Any]) -> Dict[str, Any]:
         """Validates style-specific arguments and translates them into the required
@@ -1736,10 +1597,7 @@ class BaseImage(metaclass=ImageMeta):
 
     @abstractmethod
     def _get_render_size(self) -> Tuple[int, int]:
-        """Returns the size (in pixels) required to render the image.
-
-        Applies the image scale.
-        """
+        """Returns the size (in pixels) required to render the image."""
         raise NotImplementedError
 
     @classmethod
@@ -1896,9 +1754,6 @@ class BaseImage(metaclass=ImageMeta):
             if isinstance(_size, Size):
                 self.set_size(_size)
             elif check_size or animated:
-                # NOTE: If the set size is larger than the available terminal size but
-                # the scale makes it fit in, then it's all good.
-
                 columns, lines = map(
                     sub,
                     get_terminal_size(),
@@ -1957,8 +1812,6 @@ class BaseImage(metaclass=ImageMeta):
         columns, lines = maxsize or map(sub, get_terminal_size(), (h_allow, v_allow))
         max_width = self._pixels_cols(cols=columns)
         max_height = self._pixels_lines(lines=lines)
-
-        # NOTE: The image scale is not considered since it should never be > 1
 
         # As for cell ratio...
         #
@@ -2101,7 +1954,6 @@ class GraphicsImage(BaseImage):
         *,
         width: Union[int, Size, None] = None,
         height: Union[int, Size, None] = None,
-        scale: Tuple[float, float] = (1.0, 1.0),
     ) -> None:
         # calls `is_supported()` first to set required class attributes, in case
         # support is forced for a style that is actually supported
@@ -2230,8 +2082,7 @@ class ImageIterator:
         term_image.exceptions.StyleError: Invalid style-specific format specifier.
 
     * If *repeat* equals ``1``, caching is disabled.
-    * The iterator has immediate response to changes in the image size
-      and :term:`scale`.
+    * The iterator has immediate response to changes in the image size.
     * If the image size is :term:`dynamic <dynamic size>`, it's computed per frame.
     * The number of the last yielded frame is set as the image's seek position.
     * Directly adjusting the seek position of the image doesn't affect iteration.

--- a/tests/test_image/common.py
+++ b/tests/test_image/common.py
@@ -158,7 +158,7 @@ def test_str_All():
 def test_format_All():
     image = ImageClass(python_img)
     image.set_size()
-    image.scale = 0.5  # Leave some space for formatting
+    image.width //= 2  # To ensure there's padding
     assert format(image) == image._format_render(str(image))
 
 

--- a/tests/test_image/test_block.py
+++ b/tests/test_image/test_block.py
@@ -1,7 +1,5 @@
 """BlockImage-specific tests"""
 
-from random import random
-
 from term_image.ctlseqs import SGR_BG_RGB, SGR_NORMAL
 from term_image.image import BlockImage
 from term_image.image.common import _ALPHA_THRESHOLD
@@ -30,15 +28,12 @@ class TestRender:
         return self.trans._renderer(self.trans._render_image, alpha)
 
     def test_size(self):
-        self.trans.scale = 1.0
         render = self.render_image(_ALPHA_THRESHOLD)
         # No '\n' after the last line, hence the `+ 1`
         assert render.count("\n") + 1 == self.trans.height
         assert render.partition("\n")[0].count(" ") == self.trans.width
 
     def test_transparency(self):
-        self.trans.scale = 1.0
-
         # Transparency enabled
         render = self.render_image(_ALPHA_THRESHOLD)
         assert render == str(self.trans) == f"{self.trans:1.1}"
@@ -55,8 +50,6 @@ class TestRender:
         )
 
     def test_background_colour(self):
-        self.trans.scale = 1.0
-
         # Terminal BG
         for bg in ((0,) * 3, (100,) * 3, (255,) * 3, None):
             set_fg_bg_colors(bg=bg)
@@ -96,28 +89,3 @@ class TestRender:
             line == SGR_BG_RGB % (255, 255, 255) + " " * self.trans.width + SGR_NORMAL
             for line in render.splitlines()
         )
-
-    def test_scaled(self):
-        # At varying scales
-        for self.trans.scale in map(lambda x: x / 100, range(10, 101)):
-            render = self.render_image(_ALPHA_THRESHOLD)
-            assert render.count("\n") + 1 == self.trans.rendered_height
-            assert all(
-                line == SGR_NORMAL + " " * self.trans.rendered_width + SGR_NORMAL
-                for line in render.splitlines()
-            )
-
-        # Random scales
-        for _ in range(100):
-            scale = random()
-            if scale == 0.0:
-                continue
-            self.trans.scale = scale
-            assert 0 not in self.trans.rendered_size
-
-            render = self.render_image(_ALPHA_THRESHOLD)
-            assert render.count("\n") + 1 == self.trans.rendered_height
-            assert all(
-                line == SGR_NORMAL + " " * self.trans.rendered_width + SGR_NORMAL
-                for line in render.splitlines()
-            )

--- a/tests/test_image/test_iterm2.py
+++ b/tests/test_image/test_iterm2.py
@@ -4,7 +4,6 @@ import io
 import sys
 from base64 import standard_b64decode
 from contextlib import contextmanager
-from random import random
 
 import pytest
 from PIL import Image
@@ -678,13 +677,11 @@ class TestRenderLines:
             self._test_image_size(image, term=ITerm2Image._TERM)
 
     def test_size(self):
-        self.trans.scale = 1.0
         for ITerm2Image._TERM in supported_terminals:
             self._test_image_size(self.trans, term=ITerm2Image._TERM)
 
     def test_raw_image_and_transparency(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
         pixels_per_line = w * (h // _size)
 
@@ -709,7 +706,6 @@ class TestRenderLines:
 
     def test_raw_image_and_background_colour(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
         pixels_per_line = w * (h // _size)
 
@@ -764,7 +760,6 @@ class TestRenderLines:
 
     def test_mix(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         cols = self.trans.rendered_width
 
         for ITerm2Image._TERM in supported_terminals:
@@ -792,7 +787,6 @@ class TestRenderLines:
 
     def test_compress(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
 
         # compress = 4  (default)
         assert self.render_image() == str(self.trans) == f"{self.trans:1.1+c4}"
@@ -808,23 +802,6 @@ class TestRenderLines:
             > len(self.render_image(c=1))
             > len(self.render_image(c=9))
         )
-
-    def test_scaled(self):
-        # At varying scales
-        for self.trans.scale in map(lambda x: x / 100, range(10, 101, 10)):
-            for ITerm2Image._TERM in supported_terminals:
-                self._test_image_size(self.trans, term=ITerm2Image._TERM)
-
-        # Random scales
-        for _ in range(20):
-            scale = random()
-            if scale == 0.0:
-                continue
-            self.trans.scale = scale
-
-            assert 0 not in self.trans.rendered_size
-            for ITerm2Image._TERM in supported_terminals:
-                self._test_image_size(self.trans, term=ITerm2Image._TERM)
 
     def test_jpeg(self):
         png_image = ITerm2Image.from_file("tests/images/trans.png")
@@ -956,13 +933,11 @@ class TestRenderWhole:
             self._test_image_size(image, term=ITerm2Image._TERM)
 
     def test_size(self):
-        self.trans.scale = 1.0
         for ITerm2Image._TERM in supported_terminals:
             self._test_image_size(self.trans, term=ITerm2Image._TERM)
 
     def test_raw_image_and_transparency(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
 
         # Transparency enabled
@@ -985,7 +960,6 @@ class TestRenderWhole:
 
     def test_raw_image_and_background_colour(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
 
         # Terminal BG
@@ -1038,7 +1012,6 @@ class TestRenderWhole:
 
     def test_mix(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
         cols, lines = self.trans.rendered_size
 
         for ITerm2Image._TERM in supported_terminals:
@@ -1080,7 +1053,6 @@ class TestRenderWhole:
 
     def test_compress(self):
         ITerm2Image._TERM = ""
-        self.trans.scale = 1.0
 
         # compress = 4  (default)
         assert self.render_image() == str(self.trans) == f"{self.trans:1.1+c4}"
@@ -1096,23 +1068,6 @@ class TestRenderWhole:
             > len(self.render_image(c=1))
             > len(self.render_image(c=9))
         )
-
-    def test_scaled(self):
-        # At varying scales
-        for self.trans.scale in map(lambda x: x / 100, range(10, 101, 10)):
-            for ITerm2Image._TERM in supported_terminals:
-                self._test_image_size(self.trans, term=ITerm2Image._TERM)
-
-        # Random scales
-        for _ in range(20):
-            scale = random()
-            if scale == 0.0:
-                continue
-            self.trans.scale = scale
-
-            assert 0 not in self.trans.rendered_size
-            for ITerm2Image._TERM in supported_terminals:
-                self._test_image_size(self.trans, term=ITerm2Image._TERM)
 
     def test_jpeg(self):
         png_image = ITerm2Image.from_file("tests/images/trans.png")
@@ -1215,7 +1170,7 @@ def test_read_from_file():
                 pixels=image.original_size[1]
             )
 
-            # Will not be downscale
+            # Will not be downscaled
             image.height = lines_for_original_height * 2
             for ITerm2Image._TERM in supported_terminals:
                 assert (

--- a/tests/test_image/test_kitty.py
+++ b/tests/test_image/test_kitty.py
@@ -3,7 +3,6 @@
 import io
 from base64 import standard_b64decode
 from contextlib import contextmanager
-from random import random
 from zlib import decompress
 
 import pytest
@@ -264,7 +263,6 @@ class TestRenderLines:
     def test_transmission(self):
         # Not chunked (image data is entirely contiguous, so it's highly compressed)
         # Size is tested in `test_size()`
-        self.trans.scale = 1.0
         for line in self.render_image().splitlines():
             decode_image(line)
 
@@ -300,11 +298,9 @@ class TestRenderLines:
         self._test_image_size(image)
 
     def test_size(self):
-        self.trans.scale = 1.0
         self._test_image_size(self.trans)
 
     def test_image_data_and_transparency(self):
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
         pixels_per_line = w * (h // _size)
 
@@ -326,7 +322,6 @@ class TestRenderLines:
             assert raw_image.count(b"\0\0\0") == pixels_per_line
 
     def test_image_data_and_background_colour(self):
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
         pixels_per_line = w * (h // _size)
 
@@ -376,8 +371,6 @@ class TestRenderLines:
             assert raw_image.count(b"\xff" * 3) == pixels_per_line
 
     def test_z_index(self):
-        self.trans.scale = 1.0
-
         # z_index = 0  (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+z0}"
@@ -392,8 +385,6 @@ class TestRenderLines:
                 assert ("z", f"{value}") in decode_image(line)[0]
 
     def test_mix(self):
-        self.trans.scale = 1.0
-
         # mix = False (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+m0}"
@@ -409,8 +400,6 @@ class TestRenderLines:
             assert fill == ctlseqs.CURSOR_FORWARD % self.trans.rendered_width
 
     def test_compress(self):
-        self.trans.scale = 1.0
-
         # compress = 4  (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+c4}"
@@ -438,26 +427,9 @@ class TestRenderLines:
         )
 
     def test_blend_false(self):
-        self.trans.scale = 1.0
-
         render = self.render_image(None, b=False)
         for line in render.splitlines():
             assert line.startswith(ctlseqs.KITTY_DELETE_CURSOR)
-
-    def test_scaled(self):
-        # At varying scales
-        for self.trans.scale in map(lambda x: x / 100, range(10, 101, 10)):
-            self._test_image_size(self.trans)
-
-        # Random scales
-        for _ in range(20):
-            scale = random()
-            if scale == 0.0:
-                continue
-            self.trans.scale = scale
-
-            assert 0 not in self.trans.rendered_size
-            self._test_image_size(self.trans)
 
 
 class TestRenderWhole:
@@ -490,7 +462,6 @@ class TestRenderWhole:
     def test_transmission(self):
         # Not chunked (image data is entirely contiguous, so it's highly compressed)
         # Image data size is tested in `test_size()`
-        self.trans.scale = 1.0
         decode_image(self.render_image())
 
         # Chunked (image data is very sparse, so it's still large after compression)
@@ -520,11 +491,9 @@ class TestRenderWhole:
         self._test_image_size(image)
 
     def test_size(self):
-        self.trans.scale = 1.0
         self._test_image_size(self.trans)
 
     def test_image_data_and_transparency(self):
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
 
         # Transparency enabled
@@ -544,7 +513,6 @@ class TestRenderWhole:
         assert raw_image.count(b"\0\0\0") == w * h
 
     def test_image_data_and_background_colour(self):
-        self.trans.scale = 1.0
         w, h = get_actual_render_size(self.trans)
 
         # Terminal BG
@@ -591,8 +559,6 @@ class TestRenderWhole:
         assert raw_image.count(b"\xff" * 3) == w * h
 
     def test_z_index(self):
-        self.trans.scale = 1.0
-
         # z_index = 0  (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+z0}"
@@ -606,8 +572,6 @@ class TestRenderWhole:
             assert ("z", f"{value}") in control_codes
 
     def test_mix(self):
-        self.trans.scale = 1.0
-
         # mix = False (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+m0}"
@@ -625,8 +589,6 @@ class TestRenderWhole:
         )
 
     def test_compress(self):
-        self.trans.scale = 1.0
-
         # compress = 4  (default)
         render = self.render_image()
         assert render == str(self.trans) == f"{self.trans:1.1+c4}"
@@ -644,25 +606,8 @@ class TestRenderWhole:
             assert ("o", "z") in decode_image(render)[0]
 
     def test_blend_false(self):
-        self.trans.scale = 1.0
-
         render = self.render_image(None, b=False)
         assert render.startswith(ctlseqs.KITTY_DELETE_CURSOR)
-
-    def test_scaled(self):
-        # At varying scales
-        for self.trans.scale in map(lambda x: x / 100, range(10, 101, 10)):
-            self._test_image_size(self.trans)
-
-        # Random scales
-        for _ in range(20):
-            scale = random()
-            if scale == 0.0:
-                continue
-            self.trans.scale = scale
-
-            assert 0 not in self.trans.rendered_size
-            self._test_image_size(self.trans)
 
 
 class TestClear:

--- a/tests/test_image/test_others.py
+++ b/tests/test_image/test_others.py
@@ -16,10 +16,6 @@ class TestConvinience:
         with pytest.raises(ValueError, match=r"both width and height"):
             AutoImage(python_img, width=1, height=1)
 
-        # Ensure scale argument gets through
-        with pytest.raises(TypeError, match=r"'scale'"):
-            AutoImage(python_img, scale=0.5)
-
         assert isinstance(AutoImage(python_img), BaseImage)
 
     def test_from_file(self):
@@ -29,10 +25,6 @@ class TestConvinience:
         # Ensure size arguments get through
         with pytest.raises(ValueError, match=r"both width and height"):
             from_file(python_image, width=1, height=1)
-
-        # Ensure scale argument gets through
-        with pytest.raises(TypeError, match=r"'scale'"):
-            from_file(python_image, scale=1.0)
 
         for path in (python_image, Path(python_image), BytesPath(python_image)):
             assert isinstance(from_file(path), BaseImage)

--- a/tests/test_image/test_url.py
+++ b/tests/test_image/test_url.py
@@ -42,10 +42,6 @@ def test_from_url():
     with pytest.raises(ValueError, match=r"both width and height"):
         BlockImage.from_url(python_url, width=1, height=1)
 
-    # Ensure scale argument gets through
-    with pytest.raises(TypeError, match=r"'scale'"):
-        BlockImage.from_url(python_url, scale=1.0)
-
 
 def test_source():
     image = BlockImage.from_url(python_url)
@@ -71,9 +67,5 @@ class TestConvinience:
         # Ensure size arguments get through
         with pytest.raises(ValueError, match=r"both width and height"):
             from_url(python_url, width=1, height=1)
-
-        # Ensure scale argument gets through
-        with pytest.raises(TypeError, match=r"'scale'"):
-            from_url(python_url, scale=1.0)
 
         assert isinstance(from_url(python_url), BaseImage)

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -208,15 +208,6 @@ def test_caching():
     image_it.seek(gif_image2.n_frames - 1)
     assert next(image_it).count("\n") + 1 == 20
 
-    # Change in scale
-    gif_image2.scale = 0.5
-    frame_0_3 = next(image_it)
-    assert frame_0_3 is not frame_0_1
-    assert frame_0_3 is not frame_0_2
-    assert frame_0_3.count("\n") + 1 == 10
-    image_it.seek(gif_image2.n_frames - 1)
-    assert next(image_it).count("\n") + 1 == 10
-
     image_it.close()
 
 


### PR DESCRIPTION
- Removes *scale* parameter of image constructors.
- Removes `scale`, `scale_x` and `scale_y` properties of `BaseImage`.
- Updates `rendered_size`, `rendered_width` and `rendered_height` properties of `BaseImage`.
- Erases image scaling from the docs.

Why?
1. Incoming features need to out of the way.
2. It's almost never used anyways.