### PR TITLE
Improve image sizing

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -33,15 +33,6 @@ Below are definitions of terms used across the API, exception messages and the d
 
       .. seealso:: :ref:`alignment`
 
-   allowance
-      The amount of space to be left unused on the terminal screen.
-
-   horizontal allowance
-      The amount of **columns** to be left unused on the terminal screen.
-
-   vertical allowance
-      The amount of **lines** to be left unused on the terminal screen.
-
    alpha threshold
       Alpha ratio/value above which a pixel is taken as **opaque** (applies only to :ref:`text-based`).
 
@@ -52,20 +43,20 @@ Below are definitions of terms used across the API, exception messages and the d
       
       The frames of an animated image are generally meant to be displayed in rapid succession, to give the effect of animation.
 
-   available size
-      The remainder after :term:`allowances <allowance>` are subtracted from the maximum frame size.
-
-   available width
-      The remainder after horizontal allowance is subtracted from the maximum amount of columns.
-
-   available height
-      The remainder after vertical allowance is subtracted from the maximum amount of lines.
-
    cell ratio
       The **aspect ratio** (i.e the ratio of **width to height**) of a **character cell** on a terminal screen.
 
       .. seealso::
          :py:func:`~term_image.get_cell_ratio` and :py:func:`~term_image.set_cell_ratio`
+
+   frame size
+      The dimensions of the area used in :term:`automatic sizing`.
+
+   frame width
+      The width of the area used in :term:`automatic sizing`.
+
+   frame height
+      The height of the area used in :term:`automatic sizing`.
 
    render
    rendered
@@ -148,7 +139,7 @@ Below are definitions of terms used across the API, exception messages and the d
 
    automatic size
    automatic sizing
-      A form of sizing wherein the image size is computed based on a combination of the :term:`available size`, the image's original size and a given width **or** height.
+      A form of sizing wherein the image size is computed based on a combination of the :term:`frame size`, the image's original size and a given width **or** height.
 
       This form of sizing tries to preserve image aspect ratio and can be used with both :term:`fixed sizing` and :term:`dynamic sizing`.
 

--- a/docs/source/guide/formatting.rst
+++ b/docs/source/guide/formatting.rst
@@ -115,7 +115,7 @@ Render Format Specification
 * ``width`` → :term:`padding width`
 
   * positive integer
-  * *default*: :term:`terminal width` minus :term:`horizontal allowance`
+  * *default*: :term:`terminal width`
   * if **less than or equal** to the :term:`rendered width`, it has **no effect**
 
 * ``v_align`` → :term:`vertical alignment`
@@ -128,7 +128,7 @@ Render Format Specification
 * ``height`` → :term:`padding height`
 
   * positive integer
-  * *default*: :term:`terminal height` minus :term:`vertical allowance`
+  * *default*: :term:`terminal height` minus two (``2``)
   * if **less than or equal** to the :term:`rendered height`, it has **no effect**
 
 * ``#`` → transparency setting

--- a/docs/source/issues.rst
+++ b/docs/source/issues.rst
@@ -16,11 +16,8 @@ Known Issues
      It is neither a fault of this library nor of the terminal emulators, as drawing
      of images and animations works properly with WSL within Windows Terminal.
 
-   * **Solution:** A workaround is to leave some :term:`horizontal allowance` of **at least
-     two columns** to ensure the image never reaches the right edge of the terminal.
-
-     This can be achieved in the library using the *h_allow* parameter of
-     :py:meth:`~term_image.image.BaseImage.set_size`.
+   * **Solution:** A workaround is to leave some columns between the right edge of the
+     image and the right edge of the terminal.
 
 2. Animations with the **kitty** render style on the **Kitty terminal emulator** might
    be glitchy for some images with **high resolution and size** and/or **sparse color

--- a/docs/source/start/tutorial.rst
+++ b/docs/source/start/tutorial.rst
@@ -121,9 +121,9 @@ The output (using :py:func:`print`) should look like:
 Renders the image with:
 
 * **right** :term:`horizontal alignment`
-* **automatic** :term:`padding width` (the current :term:`terminal width` minus :term:`horizontal allowance`)
+* **default** :term:`padding width` (the current :term:`terminal width`)
 * **bottom** :term:`vertical alignment`
-* **automatic** :term:`padding height` (the current :term:`terminal height` minus :term:`vertical allowance`)
+* **default** :term:`padding height` (the current :term:`terminal height` minus two (``2``))
 * transparent background with **0.5** :term:`alpha threshold`
 
 The output (using :py:func:`print`) should look like:
@@ -310,8 +310,10 @@ True
 
 .. important::
 
-   1. The currently set :term:`cell ratio` is also taken into consideration when calculating sizes for images of :ref:`text-based`.
-   2. There is a **default** 2-line :term:`vertical allowance`, to allow for shell prompts or the likes.
+   1. The currently set :term:`cell ratio` is also taken into consideration when
+      calculating sizes for images of :ref:`text-based`.
+   2. There is a **2-line** difference between the **default** :term:`frame size` and
+      the terminal size to allow for shell prompts and the likes.
 
 .. tip::
 

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -137,17 +137,17 @@ class Size(Enum):
     """Enumeration for :term:`automatic sizing`."""
 
     #: Equivalent to :py:attr:`ORIGINAL` if it will fit into the
-    #: :term:`available size`, else :py:attr:`FIT`.
+    #: :term:`frame size`, else :py:attr:`FIT`.
     #:
     #: :meta hide-value:
     AUTO = Hidden()
 
-    #: The image size is set to fit optimally **within** the :term:`available size`.
+    #: The image size is set to fit optimally **within** the :term:`frame size`.
     #:
     #: :meta hide-value:
     FIT = Hidden()
 
-    #: The size is set such that the width is exactly the :term:`available width`,
+    #: The size is set such that the width is exactly the :term:`frame width`,
     #: regardless of the :term:`cell ratio`.
     #:
     #: :meta hide-value:
@@ -442,8 +442,7 @@ class BaseImage(metaclass=ImageMeta):
             This results in a :term:`fixed size`.
 
             .. note::
-                * Default allowances apply.
-                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH` and allowances
+                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH`
                   as defined by :py:meth:`set_size` apply.
         """,
     )
@@ -565,8 +564,7 @@ class BaseImage(metaclass=ImageMeta):
             image is :term:`rendered`.
 
             .. note::
-                * Default allowances apply.
-                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH` and allowances
+                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH`
                   as defined by :py:meth:`set_size` apply.
         """,
     )
@@ -630,8 +628,7 @@ class BaseImage(metaclass=ImageMeta):
             This results in a :term:`fixed size`.
 
             .. note::
-                * Default allowances apply.
-                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH` and allowances
+                * The same conditions for :py:attr:`Size.FIT_TO_WIDTH`
                   as defined by :py:meth:`set_size` apply.
         """,
     )
@@ -691,18 +688,17 @@ class BaseImage(metaclass=ImageMeta):
               "right" / ">"). Default: center.
             pad_width: Number of columns within which to align the image.
 
-              * A positive integer or ``None``. If ``None``, the
-                :term:`available terminal width <available width>` is used.
+              * A positive integer or ``None``. If ``None``, the :term:`terminal width`
+                is used.
               * Excess columns are filled with spaces.
-              * Must not be greater than the
-                :term:`available terminal width <available width>`.
+              * Must not be greater than the :term:`terminal width`.
 
             v_align: Vertical alignment ("top"/"^", "middle"/"-" or "bottom"/"_").
               Default: middle.
             pad_height: Number of lines within which to align the image.
 
-              * A positive integer or ``None``. If ``None``, the
-                :term:`available terminal height <available height>` is used.
+              * A positive integer or ``None``. If ``None``, the :term:`terminal height`
+                is used.
               * Excess lines are filled with spaces.
               * Must not be greater than the :term:`terminal height`,
                 **for animations**.
@@ -721,8 +717,7 @@ class BaseImage(metaclass=ImageMeta):
                 * A hex color e.g ``ffffff``, ``7faa52``.
 
             scroll: Only applies to non-animations. If ``True``, allows the image's
-                :term:`rendered height` to be greater than the
-                :term:`available terminal height <available height>`.
+                :term:`rendered height` to be greater than the :term:`terminal height`.
 
             animate: If ``False``, disable animation i.e draw only the current frame of
               an animated image.
@@ -747,13 +742,9 @@ class BaseImage(metaclass=ImageMeta):
               unexpected/invalid value.
             ValueError: Unable to convert or resize image.
             term_image.exceptions.InvalidSizeError: The image's :term:`rendered size`
-              can not fit into the :term:`available terminal size <available size>`.
+              can not fit into the :term:`terminal size`.
             term_image.exceptions.StyleError: Unrecognized style-specific parameter(s).
 
-        * If :py:meth:`set_size` was used to set the image size, the horizontal and
-          vertical allowances (set when :py:meth:`set_size` was called) are taken into
-          consideration during size validation. If the size was set via another means or
-          the size is :term:`dynamic <dynamic size>`, the default allowances apply.
         * For **non-animations**, if the image size was set with
           :py:attr:`~term_image.image.Size.FIT_TO_WIDTH`, the image **height** is not
           validated and setting *scroll* is unnecessary.
@@ -1071,8 +1062,6 @@ class BaseImage(metaclass=ImageMeta):
               * a positive integer; vertical dimension of the image, in lines.
               * a :py:class:`~term_image.image.Size` enum member.
 
-            h_allow: :term:`Horizontal allowance`; a non-negative integer.
-            v_allow: :term:`Vertical allowance`; a non-negative integer.
             maxsize: If given, as ``(columns, lines)`` (where *columns* and *lines* are
               positive integers), it's used instead of the terminal size.
 
@@ -1081,7 +1070,7 @@ class BaseImage(metaclass=ImageMeta):
             ValueError: An argument is of an appropriate type but has an
               unexpected/invalid value.
             ValueError: Both *width* and *height* are specified.
-            ValueError: The :term:`available size` is too small for
+            ValueError: The :term:`frame size` is too small for
               :term:`automatic sizing`.
             term_image.exceptions.InvalidSizeError: *maxsize* is given and the
               resulting size will not fit into it.
@@ -1092,15 +1081,8 @@ class BaseImage(metaclass=ImageMeta):
         If *width* or *height* is a :py:class:`~term_image.image.Size` enum
         member, :term:`automatic sizing` applies as prescribed by the enum member.
 
-        When :py:attr:`~term_image.image.Size.FIT_TO_WIDTH` is given,
-
-        * size validation operations take it into consideration.
-        * :term:`Vertical allowance` is nullified.
-
-        :term:`Allowances <allowance>` are ignored when *maxsize* is given.
-
-        Render formatting and size validation operations recognize and respect the
-        horizontal and vertical allowances, until the image size is re-set.
+        When :py:attr:`~term_image.image.Size.FIT_TO_WIDTH` is given, size validation
+        operations take it into consideration.
 
         NOTE:
            The size is checked to fit in only when *maxsize* is given along with a fixed
@@ -1723,7 +1705,7 @@ class BaseImage(metaclass=ImageMeta):
         Raises:
             term_image.exceptions.InvalidSizeError: *check_size* or *animated* is
               ``True`` and the image's :term:`rendered size` can not fit into the
-              :term:`available terminal size <available size>`.
+              :term:`terminal size`.
             term_image.exceptions.TermImageError: The image has been finalized.
 
         NOTE:

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -561,7 +561,7 @@ class ITerm2Image(GraphicsImage):
         else:
             if not mix and self._TERM == "wezterm":
                 lines = max(
-                    (fmt or (None,))[-1] or get_terminal_size()[1] - self._v_allow,
+                    (fmt or (None,))[-1] or get_terminal_size().lines,
                     self.rendered_height,
                 )
                 r_width = self.rendered_width

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 
 import term_image
@@ -26,7 +27,7 @@ def reset_cell_size_ratio():
 
 
 def get_terminal_size():
-    return (80, 30)
+    return os.terminal_size((80, 30))
 
 
 def get_fg_bg_colors(*, hex=False):

--- a/tests/test_image/common.py
+++ b/tests/test_image/common.py
@@ -42,14 +42,12 @@ def setup_common(ImageClass):
     set_cell_size((9, 18))
     set_cell_ratio(0.5)
 
-    if ImageClass._pixels_cols(cols=columns) < ImageClass._pixels_lines(
-        lines=lines - 2
-    ):
+    if ImageClass._pixels_cols(cols=columns) < ImageClass._pixels_lines(lines=lines):
         _width = columns
         _height = width_height(dummy, w=columns)
     else:
-        _height = lines - 2
-        _width = width_height(dummy, h=lines - 2)
+        _height = lines
+        _width = width_height(dummy, h=lines)
     _width_px = ImageClass._pixels_cols(cols=_width)
     _height_px = ImageClass._pixels_lines(lines=_height)
 
@@ -231,7 +229,7 @@ class TestSetSize_All:
 
     def test_auto(self):
         max_width = ImageClass._pixels_cols(cols=columns)
-        max_height = ImageClass._pixels_lines(lines=lines - 2)
+        max_height = ImageClass._pixels_lines(lines=lines)
 
         _original_size = self.image.original_size
         try:
@@ -413,19 +411,6 @@ class TestSetSize_All:
         assert self.v_image.height == ImageClass._pixels_lines(pixels=ori_height)
         assert proportional(self.v_image)
 
-    def test_allowance(self):
-        self.h_image.set_size()
-        assert self.h_image.width == columns
-
-        self.v_image.set_size()
-        assert self.v_image.height == lines - 2
-
-        self.h_image.set_size(h_allow=2)
-        assert self.h_image.width == columns - 2
-
-        self.v_image.set_size(v_allow=3)
-        assert self.v_image.height == lines - 3
-
     def test_can_exceed_terminal_size(self):
         self.image.set_size(width=columns + 1)
         assert self.image.width == columns + 1
@@ -447,13 +432,6 @@ class TestSetSize_All:
         self.image.set_size(width=100, maxsize=(200, 100))
         assert self.image.size == (100, 50)
         self.image.set_size(height=50, maxsize=(200, 100))
-        assert self.image.size == (100, 50)
-
-    # This test passes only when the cell ratio is about 0.5
-    def test_maxsize_allowance_ignore(self):
-        self.image.set_size(h_allow=2, v_allow=3, maxsize=(100, 50))
-        assert self.image.size == (100, 50)
-        self.image.set_size(h_allow=2, v_allow=3, maxsize=(100, 50))
         assert self.image.size == (100, 50)
 
 


### PR DESCRIPTION
- Removes *h_allow* and *v_allow* parameters of `BaseImage.set_size()`.
- Removes `_h_allow` and `_v_allow` attributes of `BaseImage`.
- Removes the terms/concepts of "allowance" and "available size" from the docs.