### PR TITLE
Terminal size-relative padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Allows setting both width and height explicitly via:
     - `BaseImage.set_size()`
     - `BaseImage.size`
+- Support for terminal size-relative padding ([#91]).
 
 ### Changed
 - `UrwidImage.clear_all()` -> `UrwidImageScreen.clear_images()` ([08f4e4d]).
@@ -31,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No longer raises `ValueError`: Available size too small.
   - No longer checks if the resulting size fits into a given frame size when *width* or *height* is also given as an integer.
     - No longer raises `InvalidSizeError`.
+- **(BREAKING!)** Redefined *pad_width* and *pad_height* formatting parameters ([#91]).
+  - No longer accept `None`.
+  - Now accept non-positive integers.
+  - Changed default values to `0` and `-2` respectively.
 
 ### Removed
 - Image scaling ([#88]).

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -690,8 +690,6 @@ class BaseImage(metaclass=ImageMeta):
               "right" / ">"). Default: center.
             pad_width: Number of columns within which to align the image.
 
-              * A positive integer or ``None``. If ``None``, the :term:`terminal width`
-                is used.
               * Excess columns are filled with spaces.
               * Must not be greater than the :term:`terminal width`.
 
@@ -699,8 +697,6 @@ class BaseImage(metaclass=ImageMeta):
               Default: middle.
             pad_height: Number of lines within which to align the image.
 
-              * A positive integer or ``None``. If ``None``, the :term:`terminal height`
-                is used.
               * Excess lines are filled with spaces.
               * Must not be greater than the :term:`terminal height`,
                 **for animations**.
@@ -747,14 +743,21 @@ class BaseImage(metaclass=ImageMeta):
               can not fit into the :term:`terminal size`.
             term_image.exceptions.StyleError: Unrecognized style-specific parameter(s).
 
-        * :term:`padding width` is always validated, if not ``None``.
+        * If *pad_width* or *pad_height* is:
+
+          * positive, it is **absolute** and used as-is.
+          * non-positive, it is **relative** to the corresponding terminal dimension
+            and equivalent to the absolute dimension
+            ``max(terminal_dimension + frame_dimension, 1)``.
+
+        * :term:`padding width` is always validated.
         * *animate*, *repeat* and *cached* apply to :term:`animated` images only.
           They are simply ignored for non-animated images.
         * For animations (i.e animated images with *animate* set to ``True``):
 
           * *scroll* is ignored.
           * Image size is always validated, if set.
-          * :term:`Padding height` is always validated, if not ``None``.
+          * :term:`Padding height` is always validated.
           * **with the exception of native animations provided by some render styles**.
 
         * Animations, **by default**, are infinitely looped and can be terminated
@@ -1407,7 +1410,7 @@ class BaseImage(metaclass=ImageMeta):
         v_align: Optional[str] = None,
         height: int = -2,
     ) -> str:
-        """Formats rendered image text.
+        """Pads and aligns a primary render output.
 
         All arguments should be passed through ``_check_formatting()`` first.
         """

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -560,8 +560,13 @@ class ITerm2Image(GraphicsImage):
                     pass
         else:
             if not mix and self._TERM == "wezterm":
+                pad_height = fmt[-1]
                 lines = max(
-                    (fmt or (None,))[-1] or get_terminal_size().lines,
+                    (
+                        pad_height
+                        if pad_height > 0
+                        else get_terminal_size().lines + pad_height
+                    ),
                     self.rendered_height,
                 )
                 r_width = self.rendered_width

--- a/tests/test_image/test_base.py
+++ b/tests/test_image/test_base.py
@@ -841,6 +841,20 @@ class TestFormatting:
         ):
             self.check_padding(result, ">", width, None, 15)
 
+    def test_padding_width_relative(self):
+        # terminal width = 80
+        for relative, width, result in (
+            (0, 80, (0, 65, 0, 0)),
+            (-1, 79, (0, 64, 0, 0)),
+            (-2, 78, (0, 63, 0, 0)),
+            (-64, 16, (0, 1, 0, 0)),
+            (-65, 15, (0, 0, 0, 0)),
+            (-80, 1, (0, 0, 0, 0)),
+            (-100, 1, (0, 0, 0, 0)),
+        ):
+            self.check_padding(result, ">", width, None, 15)
+            self.check_padding(result, ">", relative, None, 15)
+
     def test_padding_height_top(self):
         for height, result in (
             (15, (0, 0, 0, 0)),
@@ -871,6 +885,20 @@ class TestFormatting:
             (30, (15, 0, 0, 0)),
         ):
             self.check_padding(result, None, 15, "_", height)
+
+    def test_padding_height_relative(self):
+        # terminal height = 30
+        for relative, height, result in (
+            (0, 30, (15, 0, 0, 0)),
+            (-1, 29, (14, 0, 0, 0)),
+            (-2, 28, (13, 0, 0, 0)),
+            (-14, 16, (1, 0, 0, 0)),
+            (-15, 15, (0, 0, 0, 0)),
+            (-30, 1, (0, 0, 0, 0)),
+            (-50, 1, (0, 0, 0, 0)),
+        ):
+            self.check_padding(result, None, 15, "_", height)
+            self.check_padding(result, None, 15, "_", relative)
 
     def test_mixed_align(self):
         self.check_padding((0, 0, 15, 15), "<", 30, "^", 30)


### PR DESCRIPTION
- Adds support for terminal size-relative padding.
  - Compensates for removal of allowances.
- Redefines *pad_width* and *pad_height* formatting parameters.
  - No longer accept `None`.
  - Now accept non-positive integers.
  - Changed default values to `0` and `-2` respectively.