### PR TITLE
Remove style-specific exceptions

### DIFF
--- a/src/term_image/exceptions.py
+++ b/src/term_image/exceptions.py
@@ -21,9 +21,6 @@ class InvalidSizeError(TermImageError):
     """Raised for invalid image sizes."""
 
 
-# Style-specific exceptions
-
-
 class StyleError(TermImageError):
     """Baseclass of style-specific exceptions.
 
@@ -39,39 +36,6 @@ class StyleError(TermImageError):
     """
 
 
-class GraphicsImageError(StyleError):
-    """Raised for errors specific to :py:class:`~term_image.image.GraphicsImage`
-    and its subclasses defined outside this package.
-    """
-
-
-class TextImageError(StyleError):
-    """Raised for errors specific to :py:class:`~term_image.image.TextImage`
-    and its subclasses defined outside this package.
-    """
-
-
-class BlockImageError(TextImageError):
-    """Raised for errors specific to :py:class:`~term_image.image.BlockImage`
-    and its subclasses defined outside this package.
-    """
-
-
-class ITerm2ImageError(GraphicsImageError):
-    """Raised for errors specific to :py:class:`~term_image.image.ITerm2Image`
-    and its subclasses defined outside this package.
-    """
-
-
-class KittyImageError(GraphicsImageError):
-    """Raised for errors specific to :py:class:`~term_image.image.KittyImage`
-    and its subclasses defined outside this package.
-    """
-
-
-# Widgets
-
-
 class UrwidImageError(TermImageError):
     """Raised for errors specific to :py:class:`~term_image.widget.UrwidImage`."""
 
@@ -81,10 +45,3 @@ __all__ = ["TermImageWarning"] + [
     for name, obj in vars().items()
     if isinstance(obj, type) and issubclass(obj, TermImageError)
 ]
-BaseImageError = StyleError  # Only to simplify `_style_error()`
-
-
-def _style_error(cls: type):
-    for cls in cls.__mro__:
-        if cls.__module__.startswith("term_image.image"):
-            return globals()[f"{cls.__name__}Error"]

--- a/src/term_image/exceptions.py
+++ b/src/term_image/exceptions.py
@@ -22,18 +22,7 @@ class InvalidSizeError(TermImageError):
 
 
 class StyleError(TermImageError):
-    """Baseclass of style-specific exceptions.
-
-    Never raised for errors pertaining to image classes defined in this package.
-    Instead, the exception subclass specific to each image class is raised.
-
-    Only raised for subclasses of :py:class:`~term_image.image.BaseImage`
-    defined outside this package (which are not subclasses of any other image class
-    defined in this package).
-
-    Being the baseclass of all style-specific exceptions, it can be used be used to
-    handle any style-specific error, regardless of the render style it originated from.
-    """
+    """Raised for errors pertaining to the Style API."""
 
 
 class UrwidImageError(TermImageError):

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -37,12 +37,7 @@ from PIL import Image, UnidentifiedImageError
 
 from .. import get_cell_ratio
 from ..ctlseqs import CURSOR_DOWN, CURSOR_UP, HIDE_CURSOR, SGR_NORMAL, SHOW_CURSOR
-from ..exceptions import (
-    InvalidSizeError,
-    TermImageError,
-    URLNotFoundError,
-    _style_error,
-)
+from ..exceptions import InvalidSizeError, StyleError, TermImageError, URLNotFoundError
 from ..utils import (
     ClassInstanceMethod,
     ClassProperty,
@@ -1246,8 +1241,9 @@ class BaseImage(metaclass=ImageMeta):
                 for other_cls in cls.__mro__:
                     # less costly than memebership tests on every class' __bases__
                     if other_cls is __class__:
-                        raise _style_error(cls)(
-                            f"Unknown style-specific parameter {name!r}"
+                        raise StyleError(
+                            f"Unknown style-specific render parameter {name!r} for "
+                            f"{cls.__name__!r}"
                         )
 
                     if not issubclass(
@@ -1263,8 +1259,9 @@ class BaseImage(metaclass=ImageMeta):
                     except KeyError:
                         pass
                 else:
-                    raise _style_error(cls)(
-                        f"Unknown style-specific parameter {name!r}"
+                    raise StyleError(
+                        f"Unknown style-specific render parameter {name!r} for "
+                        f"{cls.__name__!r}"
                     )
 
             if not check_type(value):
@@ -1318,8 +1315,9 @@ class BaseImage(metaclass=ImageMeta):
         level of the call chain.
         """
         if spec:
-            raise _style_error(cls)(
-                f"Invalid style-specific format specifier {original!r}"
+            raise StyleError(
+                f"Invalid style-specific format specifier {original!r} "
+                f"for {cls.__name__!r}"
                 + (f", detected at {spec!r}" if spec != original else "")
             )
         return {}
@@ -1630,9 +1628,9 @@ class BaseImage(metaclass=ImageMeta):
 
         parent, invalid = spec[:start], spec[end:]
         if invalid:
-            raise _style_error(cls)(
-                f"Invalid style-specific format specifier {original!r}"
-                f", detected at {invalid!r}"
+            raise StyleError(
+                f"Invalid style-specific format specifier {original!r} "
+                f"for {cls.__name__!r}, detected at {invalid!r}"
             )
 
         return parent, fields
@@ -1909,8 +1907,8 @@ class GraphicsImage(BaseImage):
         # calls `is_supported()` first to set required class attributes, in case
         # support is forced for a style that is actually supported
         if not (cls.is_supported() or cls._forced_support):
-            raise _style_error(cls)(
-                "This render style is not supported in the active terminal"
+            raise StyleError(
+                f"{cls.__name__!r} is not supported in the active terminal"
             )
         return super().__new__(cls)
 

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -17,7 +17,7 @@ from .. import ctlseqs
 
 # These sequences are used during performance-critical operations that occur often
 from ..ctlseqs import CURSOR_FORWARD, CURSOR_UP, ERASE_CHARS, ITERM2_START, ST
-from ..exceptions import TermImageWarning, _style_error
+from ..exceptions import StyleError, TermImageWarning
 from ..utils import (
     ClassInstanceProperty,
     ClassProperty,
@@ -600,9 +600,9 @@ class ITerm2Image(GraphicsImage):
                         img.save(compressed_image, img.format, save_all=True)
                     except ValueError:
                         self._close_image(img)
-                        raise _style_error(type(self))(
+                        raise StyleError(
                             "Native animation not supported: This image was sourced "
-                            "from a PIL image of an unknown format"
+                            "from a PIL image with an unknown format"
                         ) from None
             else:
                 compressed_image = open(self._source, "rb")

--- a/tests/test_image/common.py
+++ b/tests/test_image/common.py
@@ -7,8 +7,9 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from term_image import exceptions, set_cell_ratio
+from term_image import set_cell_ratio
 from term_image.ctlseqs import SGR_BG_RGB, SGR_NORMAL
+from term_image.exceptions import StyleError
 from term_image.image.common import _ALPHA_THRESHOLD, GraphicsImage, Size, TextImage
 from term_image.utils import get_fg_bg_colors, get_terminal_size
 
@@ -148,7 +149,7 @@ def test_instantiation_Graphics():
         ImageClass._supported = True
         assert isinstance(ImageClass(python_img), GraphicsImage)
         ImageClass._supported = False
-        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+        with pytest.raises(StyleError):
             ImageClass(python_img)
     finally:
         ImageClass._supported = original
@@ -174,14 +175,14 @@ def test_forced_support_Graphics():
     original = ImageClass._supported
     try:
         ImageClass._supported = False
-        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+        with pytest.raises(StyleError):
             ImageClass(python_img)
 
         ImageClass.forced_support = True
         assert isinstance(ImageClass(python_img), GraphicsImage)
 
         ImageClass.forced_support = False
-        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+        with pytest.raises(StyleError):
             ImageClass(python_img)
     finally:
         ImageClass._supported = original
@@ -553,14 +554,14 @@ def test_render_clean_up_All():
 
 def test_style_args_All():
     image = ImageClass(python_img)
-    with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+    with pytest.raises(StyleError):
         image.draw(_=None)
 
 
 def test_style_format_spec_All():
     image = ImageClass(python_img)
     for spec in ("+\t", "20+\r", ".^+\a", "#+\0"):
-        with pytest.raises(getattr(exceptions, f"{ImageClass.__name__}Error")):
+        with pytest.raises(StyleError):
             format(image, spec)
 
 

--- a/tests/test_image/test_iterm2.py
+++ b/tests/test_image/test_iterm2.py
@@ -11,7 +11,7 @@ from PIL.PngImagePlugin import PngImageFile
 from PIL.WebPImagePlugin import WebPImageFile
 
 from term_image import ctlseqs
-from term_image.exceptions import ITerm2ImageError, TermImageWarning
+from term_image.exceptions import StyleError, TermImageWarning
 from term_image.image import iterm2
 from term_image.image.iterm2 import ANIM, LINES, WHOLE, ITerm2Image
 
@@ -526,7 +526,7 @@ def test_style_format_spec():
         "m0 ",
         "  m1c3  ",
     ):
-        with pytest.raises(ITerm2ImageError, match="format spec"):
+        with pytest.raises(StyleError, match="format spec"):
             ITerm2Image._check_style_format_spec(spec, spec)
 
     for spec, args in (
@@ -547,7 +547,7 @@ def test_style_format_spec():
 class TestStyleArgs:
     def test_unknown(self):
         for args in ({"c": 1}, {"m": True}, {" ": None}, {"xxxx": True}):
-            with pytest.raises(ITerm2ImageError, match="Unknown style-specific"):
+            with pytest.raises(StyleError, match="Unknown style-specific"):
                 ITerm2Image._check_style_args(args)
 
     def test_method(self):
@@ -1208,9 +1208,7 @@ class TestRenderAnim:
     # No image file and unknown format
     def test_unknown_format(self):
         self.no_file_img.format = None
-        with pytest.raises(
-            ITerm2ImageError, match="Native animation .* unknown format"
-        ):
+        with pytest.raises(StyleError, match="Native animation .* unknown format"):
             self.render_native_anim(self.no_file_image)
 
     # Image data size limit

--- a/tests/test_image/test_kitty.py
+++ b/tests/test_image/test_kitty.py
@@ -8,7 +8,7 @@ from zlib import decompress
 import pytest
 
 from term_image import ctlseqs
-from term_image.exceptions import KittyImageError
+from term_image.exceptions import StyleError
 from term_image.image import kitty
 from term_image.image.kitty import LINES, WHOLE, KittyImage
 
@@ -86,7 +86,7 @@ def test_style_format_spec():
         "m0 ",
         "  z1c1  ",
     ):
-        with pytest.raises(KittyImageError, match="format spec"):
+        with pytest.raises(StyleError, match="format spec"):
             KittyImage._check_style_format_spec(spec, spec)
 
     for spec, args in (
@@ -111,7 +111,7 @@ def test_style_format_spec():
 class TestStyleArgs:
     def test_unknown(self):
         for args in ({"z": 1}, {"m": True}, {" ": None}, {"xxxx": True}):
-            with pytest.raises(KittyImageError, match="Unknown style-specific"):
+            with pytest.raises(StyleError, match="Unknown style-specific"):
                 KittyImage._check_style_args(args)
 
     def test_method(self):


### PR DESCRIPTION
- Removes the following from `.exceptions`:
  - `BaseImageError`
  - `GraphicsImageError`
  - `TextImageError`
  - `BlockImageError`
  - `ITerm2ImageError`
  - `KittyImageError`
  - `_style_error()`
- Raises `StyleError` instead of style-specific exceptions.
- Update description of `StyleError`.