### PR TITLE
Raise a unique exception for render errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `BaseImage.size`
 - Support for terminal size-relative padding ([#91]).
 - `ANIM` render method to the `iterm2` render style ([#92]).
+- `term_image.exceptions.RenderError` ([#94]).
 
 ### Changed
 - `UrwidImage.clear_all()` -> `UrwidImageScreen.clear_images()` ([08f4e4d]).
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed default values to `0` and `-2` respectively.
 - Swapped `N` for `A` in the *method* field of the `iterm2` style-speific render format specification ([#92]).
 - `StyleError` is now raised instead of style-specific exceptions ([#93]).
+- **(BREAKING!)** `term_image.exceptions.RenderError` is now raised for errors that occur during rendering ([#94]).
 
 ### Removed
 - Image scaling ([#88]).
@@ -66,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#91]: https://github.com/AnonymouX47/term-image/pull/91
 [#92]: https://github.com/AnonymouX47/term-image/pull/92
 [#93]: https://github.com/AnonymouX47/term-image/pull/93
+[#94]: https://github.com/AnonymouX47/term-image/pull/94
 [08f4e4d]: https://github.com/AnonymouX47/term-image/commit/08f4e4d1514313bbd4278dadde46d21d0b11ed1f
 [fa47742]: https://github.com/AnonymouX47/term-image/commit/fa477424c83474256d4972c4b2cdd4a765bc1cda
 [ed3baa3]: https://github.com/AnonymouX47/term-image/commit/ed3baa38d7621720c007f4662f89d7abadd76ec3

--- a/src/term_image/exceptions.py
+++ b/src/term_image/exceptions.py
@@ -21,6 +21,14 @@ class InvalidSizeError(TermImageError):
     """Raised for invalid image sizes."""
 
 
+class RenderError(TermImageError):
+    """Raised for errors that occur **during** :term:`rendering`.
+
+    If the direct cause of the error is an exception, it should typically be attached
+    as the context of this exception i.e ``raise RenderError(...) from exc``.
+    """
+
+
 class StyleError(TermImageError):
     """Raised for errors pertaining to the Style API."""
 

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -37,7 +37,13 @@ from PIL import Image, UnidentifiedImageError
 
 from .. import get_cell_ratio
 from ..ctlseqs import CURSOR_DOWN, CURSOR_UP, HIDE_CURSOR, SGR_NORMAL, SHOW_CURSOR
-from ..exceptions import InvalidSizeError, StyleError, TermImageError, URLNotFoundError
+from ..exceptions import (
+    InvalidSizeError,
+    RenderError,
+    StyleError,
+    TermImageError,
+    URLNotFoundError,
+)
 from ..utils import (
     ClassInstanceMethod,
     ClassProperty,
@@ -1502,7 +1508,7 @@ class BaseImage(metaclass=ImageMeta):
                     img = img.convert(mode)
                 # Possible for images in some modes e.g "La"
                 except Exception as e:
-                    raise ValueError("Unable to convert image") from e
+                    raise RenderError("Unable to convert image") from e
                 finally:
                     if frame_img is not prev_img:
                         self._close_image(prev_img)
@@ -1513,7 +1519,7 @@ class BaseImage(metaclass=ImageMeta):
                     img = img.resize(size, Image.Resampling.BOX)
                 # Highly unlikely since render size can never be zero
                 except Exception as e:
-                    raise ValueError("Unable to resize image") from e
+                    raise RenderError("Unable to resize image") from e
                 finally:
                     if frame_img is not prev_img:
                         self._close_image(prev_img)

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -739,10 +739,11 @@ class BaseImage(metaclass=ImageMeta):
             TypeError: An argument is of an inappropriate type.
             ValueError: An argument is of an appropriate type but has an
               unexpected/invalid value.
-            ValueError: Unable to convert or resize image.
             term_image.exceptions.InvalidSizeError: The image's :term:`rendered size`
               can not fit into the :term:`terminal size`.
             term_image.exceptions.StyleError: Unrecognized style-specific parameter(s).
+            term_image.exceptions.RenderError: An error occured during
+              :term:`rendering`.
 
         * If *pad_width* or *pad_height* is:
 

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -17,7 +17,7 @@ from .. import ctlseqs
 
 # These sequences are used during performance-critical operations that occur often
 from ..ctlseqs import CURSOR_FORWARD, CURSOR_UP, ERASE_CHARS, ITERM2_START, ST
-from ..exceptions import StyleError, TermImageWarning
+from ..exceptions import RenderError, TermImageWarning
 from ..utils import (
     ClassInstanceProperty,
     ClassProperty,
@@ -598,12 +598,12 @@ class ITerm2Image(GraphicsImage):
                     compressed_image = io.BytesIO()
                     try:
                         img.save(compressed_image, img.format, save_all=True)
-                    except ValueError:
+                    except ValueError as e:
                         self._close_image(img)
-                        raise StyleError(
-                            "Native animation not supported: This image was sourced "
-                            "from a PIL image with an unknown format"
-                        ) from None
+                        raise RenderError(
+                            "iTerm2 native animation not supported: This image was "
+                            "sourced from a PIL image with an unknown format"
+                        ) from e
             else:
                 compressed_image = open(self._source, "rb")
 

--- a/tests/test_image/test_iterm2.py
+++ b/tests/test_image/test_iterm2.py
@@ -11,7 +11,7 @@ from PIL.PngImagePlugin import PngImageFile
 from PIL.WebPImagePlugin import WebPImageFile
 
 from term_image import ctlseqs
-from term_image.exceptions import StyleError, TermImageWarning
+from term_image.exceptions import RenderError, StyleError, TermImageWarning
 from term_image.image import iterm2
 from term_image.image.iterm2 import ANIM, LINES, WHOLE, ITerm2Image
 
@@ -1208,7 +1208,7 @@ class TestRenderAnim:
     # No image file and unknown format
     def test_unknown_format(self):
         self.no_file_img.format = None
-        with pytest.raises(StyleError, match="Native animation .* unknown format"):
+        with pytest.raises(RenderError, match="native animation .* unknown format"):
             self.render_native_anim(self.no_file_image)
 
     # Image data size limit

--- a/tests/test_widget/test_urwid.py
+++ b/tests/test_widget/test_urwid.py
@@ -8,7 +8,7 @@ import urwid
 from PIL import Image
 
 from term_image import ctlseqs
-from term_image.exceptions import UrwidImageError
+from term_image.exceptions import RenderError, UrwidImageError
 from term_image.image import (
     BlockImage,
     GraphicsImage,
@@ -60,7 +60,7 @@ class TestWidget:
         image_w = UrwidImage(image)
         placeholder = urwid.SolidFill("?")
 
-        with pytest.raises(ValueError, match="convert"):
+        with pytest.raises(RenderError, match="convert"):
             image_w.render(_size)
 
         image_w.set_error_placeholder(placeholder)


### PR DESCRIPTION
- Adds `.exceptions.RenderError`.
- Replaces all exception classes raised during rendering with `.exceptions.RenderError`.
- Updates `iterm2` native anim render error.