### PR TITLE
Rework class[-instance] properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swapped `N` for `A` in the *method* field of the `iterm2` style-speific render format specification ([#92]).
 - **(BREAKING!)** `term_image.exceptions.StyleError` is now raised instead of style-specific exceptions ([#93]).
 - **(BREAKING!)** `term_image.exceptions.RenderError` is now raised for errors that occur during rendering ([#94]).
+- **(BREAKING!)** `BaseImage.forced_support` can no longer be set via instances ([#95]).
+- **(BREAKING!)** `ITerm2Image.native_anim_max_bytes` can no longer be set or deleted via instances ([#95]).
 
 ### Removed
 - Image scaling ([#88]).
@@ -69,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#92]: https://github.com/AnonymouX47/term-image/pull/92
 [#93]: https://github.com/AnonymouX47/term-image/pull/93
 [#94]: https://github.com/AnonymouX47/term-image/pull/94
+[#95]: https://github.com/AnonymouX47/term-image/pull/95
 [08f4e4d]: https://github.com/AnonymouX47/term-image/commit/08f4e4d1514313bbd4278dadde46d21d0b11ed1f
 [fa47742]: https://github.com/AnonymouX47/term-image/commit/fa477424c83474256d4972c4b2cdd4a765bc1cda
 [ed3baa3]: https://github.com/AnonymouX47/term-image/commit/ed3baa38d7621720c007f4662f89d7abadd76ec3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,8 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 from term_image import __version__, utils
+from term_image.image.common import ImageMeta
+from term_image.image.iterm2 import ITerm2ImageMeta
 
 # -- Path setup --------------------------------------------------------------
 
@@ -100,6 +102,9 @@ def setup(app):
 
 # -- Extras -----------------------------------------------------------
 
-# The overidding `__get__()`s do not return the descriptor itself
-utils.ClassInstanceProperty.__get__ = property.__get__
-utils.ClassProperty.__get__ = property.__get__
+# The properties defined by the metaclass' would be invoked instead of returning the
+# property defined by the class
+for meta in (ImageMeta, ITerm2ImageMeta):
+    for attr, value in tuple(vars(meta).items()):
+        if isinstance(value, utils.ClassPropertyBase):
+            delattr(meta, attr)

--- a/src/term_image/image/common.py
+++ b/src/term_image/image/common.py
@@ -377,10 +377,13 @@ class BaseImage(metaclass=ImageMeta):
         :type: bool
 
         GET:
-            Returns the forced support status of the render style of the invoker.
+            Returns the forced support status of the invoking class or class of the
+            invoking instance.
 
         SET:
-            Forced support is enabled or disabled for the render style of the invoker.
+            Forced support is enabled or disabled for the invoking class.
+
+            Can not be set on an instance.
 
         If forced support is:
 
@@ -389,8 +392,7 @@ class BaseImage(metaclass=ImageMeta):
         * **disabled**, the return value of :py:meth:`is_supported` determines if
           the render style is supported or not.
 
-        By **default**, forced support is **disabled** by the base style class
-        (:py:class:`BaseImage`).
+        By **default**, forced support is **disabled** for all render style classes.
 
         NOTE:
             * This property is :term:`descendant`.

--- a/src/term_image/image/iterm2.py
+++ b/src/term_image/image/iterm2.py
@@ -313,7 +313,7 @@ class ITerm2Image(GraphicsImage, metaclass=ITerm2ImageMeta):
 
         GET:
             Returns the effective JPEG encoding quality of the invoker
-            (negative if disabled).
+            (class or instance).
 
         SET:
             If invoked via:
@@ -337,9 +337,9 @@ class ITerm2Image(GraphicsImage, metaclass=ITerm2ImageMeta):
         * a **class**, it uses that of its parent *iterm2* style class (if any) or the
           default (disabled), if unset for all parents or the class has no parent
           *iterm2* style class.
-        * an **instance**, it uses that of it's class.
+        * an **instance**, it uses that of its class.
 
-        By **default**, the quality is **unset** i.e JPEG encoding is **disabled** and
+        By **default**, the quality is **unset** (i.e JPEG encoding is **disabled**) and
         images are encoded in the PNG format (when not reading directly from file) but
         in some cases, higher and/or faster compression may be desired.
         JPEG encoding is significantly faster than PNG encoding and produces smaller
@@ -377,24 +377,26 @@ class ITerm2Image(GraphicsImage, metaclass=ITerm2ImageMeta):
             Returns the set value.
 
         SET:
-            A positive integer; the value is set on the *iterm2* render style baseclass
-            (:py:class:`ITerm2Image`).
+            A positive integer; the value is set.
+
+            Can not be set via an instance.
 
         DELETE:
-            The value is unset, thereby resetting it to the default.
+            The value is reset to the default.
+
+            Can not be reset via an instance.
 
         :py:class:`~term_image.exceptions.TermImageWarning` is issued (and shown
-        **only the first time**, except a filter is set to do otherwise) if the
-        image data size for a native animation is above this value.
+        **only the first time**, except the warning filters are modified to do
+        otherwise) if the image data size for a native animation is above this value.
 
         NOTE:
-            This property is :term:`descendant` but is always unset for all subclasses
-            and instances. Hence, setting/resetting it on this class, a subclass or an
-            instance affects this class, all its subclasses and all their instances.
+            This property is a global setting. Hence, setting/resetting it on this
+            class or any subclass affects all classes and their instances.
 
         WARNING:
             This property should be altered with caution to avoid excessive memory
-            usage.
+            usage, particularly on the terminal emulator's end.
         """,
     )
 
@@ -407,7 +409,8 @@ class ITerm2Image(GraphicsImage, metaclass=ITerm2ImageMeta):
         :type: bool
 
         GET:
-            Returns the effective read-from-file policy of the invoker.
+            Returns the effective read-from-file policy of the invoker
+            (class or instance).
 
         SET:
             If invoked via:
@@ -432,7 +435,7 @@ class ITerm2Image(GraphicsImage, metaclass=ITerm2ImageMeta):
         * a **class**, it uses that of its parent *iterm2* style class (if any) or the
           default (``True``), if unset for all parents or the class has no parent
           *iterm2* style class.
-        * an **instance**, it uses that of it's class.
+        * an **instance**, it uses that of its class.
 
         By **default**, the policy is **unset**, which is equivalent to ``True``
         i.e the optimization is **enabled**.

--- a/tests/test_image/test_base.py
+++ b/tests/test_image/test_base.py
@@ -158,9 +158,20 @@ class TestProperties:
         class C(B):
             pass
 
+        instance = BlockImage(python_img)
+
         for value in (1, 1.0, "1", ()):
             with pytest.raises(TypeError):
                 A.forced_support = value
+
+        with pytest.raises(AttributeError):
+            del BaseImage.forced_support
+
+        with pytest.raises(AttributeError):
+            instance.forced_support = True
+
+        with pytest.raises(AttributeError):
+            del instance.forced_support
 
         assert not A.forced_support
         assert not B.forced_support

--- a/tests/test_image/test_iterm2.py
+++ b/tests/test_image/test_iterm2.py
@@ -223,13 +223,19 @@ class TestProperties:
                 with pytest.raises(ValueError):
                     ITerm2Image.native_anim_max_bytes = value
 
+            for instance in (a, b):
+                with pytest.raises(AttributeError):
+                    instance.native_anim_max_bytes = 400
+                with pytest.raises(AttributeError):
+                    del instance.native_anim_max_bytes
+
             A.native_anim_max_bytes = 1
             assert A.native_anim_max_bytes == 1
             assert B.native_anim_max_bytes == 1
             assert a.native_anim_max_bytes == 1
             assert b.native_anim_max_bytes == 1
 
-            del b.native_anim_max_bytes
+            del B.native_anim_max_bytes
             assert A.native_anim_max_bytes == default
             assert B.native_anim_max_bytes == default
             assert a.native_anim_max_bytes == default
@@ -240,30 +246,6 @@ class TestProperties:
             assert B.native_anim_max_bytes == 200
             assert a.native_anim_max_bytes == 200
             assert b.native_anim_max_bytes == 200
-
-            del a.native_anim_max_bytes
-            assert A.native_anim_max_bytes == default
-            assert B.native_anim_max_bytes == default
-            assert a.native_anim_max_bytes == default
-            assert b.native_anim_max_bytes == default
-
-            a.native_anim_max_bytes = 300
-            assert A.native_anim_max_bytes == 300
-            assert B.native_anim_max_bytes == 300
-            assert a.native_anim_max_bytes == 300
-            assert b.native_anim_max_bytes == 300
-
-            del B.native_anim_max_bytes
-            assert A.native_anim_max_bytes == default
-            assert B.native_anim_max_bytes == default
-            assert a.native_anim_max_bytes == default
-            assert b.native_anim_max_bytes == default
-
-            b.native_anim_max_bytes = 400
-            assert A.native_anim_max_bytes == 400
-            assert B.native_anim_max_bytes == 400
-            assert a.native_anim_max_bytes == 400
-            assert b.native_anim_max_bytes == 400
 
             del A.native_anim_max_bytes
             assert A.native_anim_max_bytes == default


### PR DESCRIPTION
- Adds `.image.iterm2.ITerm2ImageMeta` metaclass for the *iterm2* render style.
- Re-implements class invokation of class[-instance] properties using properties defined on the metaclass. This affects:
  - `BaseImage.forced_support`
  - `ITerm2Image.jpeg_quality`
  - `ITerm2Image.native_anim_max_bytes`
  - `ITerm2Image.read_from_file`
- `BaseImage.forced_support` can no longer be set via instances.
- `ITerm2Image.native_anim_max_bytes` can no longer be set or deleted via instances.
- Removes `.utils.ClassPropertyMeta`.
- Redefines `ClassProperty` and `ClassInstanceProperty` in `.utils` for documentation purposes only.