### PR TITLE
The Geometry API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AttributeError` in some top-level functions ([497d9b7])
 - Formatting of some `ValueError` exception messages ([d296a31])
 
+### Added
+- `term_image.geometry` submodule ([#96]).
+  - `term_image.geometry.Size`.
+- `term_image.utils.get_cell_size()` now returns `term_image.geometry.Size` instances in place of tuples ([#96]).
 
+
+[#96]: https://github.com/AnonymouX47/term-image/pull/96
 [497d9b7]: https://github.com/AnonymouX47/term-image/commit/497d9b70dd74605e6589b81bea2fcac22efc684b
 [d296a31]: https://github.com/AnonymouX47/term-image/commit/d296a3110882449f6717959400abbc5fa1bd0891
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ pytest := pytest -v
 ## Filepath variables
 
 test-top := tests/test_top_level.py
+test-geometry := tests/test_geometry.py
 test-base := tests/test_image/test_base.py
 test-block := tests/test_image/test_block.py
 test-kitty := tests/test_image/test_kitty.py
@@ -75,13 +76,13 @@ test-text := $(test-block)
 test-graphics := $(test-kitty) $(test-iterm2)
 test-image := $(test-base) $(test-text) $(test-graphics) $(test-others)
 test-widget := $(test-urwid)
-test := $(test-top) $(test-image) $(test-iterator) $(test-widget)
+test := $(test-top) $(test-geometry) $(test-image) $(test-iterator) $(test-widget)
 test-all := $(test) $(test-url)
 
 ## Targets
 
 test-all test test-image test-text test-graphics test-widget \
-test-top test-base test-block test-kitty test-iterm2 test-url test-others test-iterator test-urwid:
+test-top test-geometry test-base test-block test-kitty test-iterm2 test-url test-others test-iterator test-urwid:
 	$(pytest) $($@)
 
 

--- a/docs/source/api/geometry.rst
+++ b/docs/source/api/geometry.rst
@@ -1,0 +1,4 @@
+``geometry`` Module
+===================
+
+.. automodule:: term_image.geometry

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -22,5 +22,6 @@ API Reference
    toplevel
    image
    widget
+   geometry
    exceptions
    utils

--- a/src/term_image/__init__.py
+++ b/src/term_image/__init__.py
@@ -25,6 +25,7 @@ from enum import Enum, auto
 from operator import truediv
 from typing import ClassVar, Union
 
+from . import geometry  # noqa: F401; # Prevent circular import against `.utils`
 from . import utils
 from .exceptions import TermImageError
 

--- a/src/term_image/geometry.py
+++ b/src/term_image/geometry.py
@@ -1,0 +1,40 @@
+"""
+.. The Geometry API
+"""
+
+from __future__ import annotations
+
+__all__ = ("Size",)
+
+from .utils import arg_type_error
+
+
+class Size(tuple):
+    """The dimensions of a rectangular region.
+
+    Args:
+        width: The horizontal dimension
+        height: The vertical dimension
+
+    Raises:
+        TypeError: An argument is of an inappropriate type.
+
+    NOTE:
+        * The meaning of a negative dimension is determined by the recieving interface.
+        * This is a subclass of :py:class:`tuple`. Hence, instances can be used anyway
+          and anywhere tuples can.
+    """
+
+    def __new__(cls, width: int, height: int):
+        if not isinstance(width, int):
+            raise arg_type_error("width", width)
+        if not isinstance(height, int):
+            raise arg_type_error("height", height)
+
+        return super().__new__(cls, (width, height))
+
+    width = property(lambda self: self[0], "The horizontal dimension")
+    height = property(lambda self: self[1], "The vertical dimension")
+
+    def __repr__(self):
+        return f"{type(self).__name__}{super().__repr__()}"

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -27,7 +27,7 @@ from time import monotonic
 from types import FunctionType
 from typing import Any, Callable, Optional, Tuple, Union
 
-from . import ctlseqs
+from . import ctlseqs, geometry
 from .exceptions import TermImageWarning
 
 # import logging
@@ -341,7 +341,7 @@ def color(
 
 
 @unix_tty_only
-def get_cell_size() -> Optional[Tuple[int, int]]:
+def get_cell_size() -> geometry.Size | None:
     """Returns the current size of a character cell in the :term:`active terminal`.
 
     Returns:
@@ -361,7 +361,7 @@ def get_cell_size() -> Optional[Tuple[int, int]]:
         ts = get_terminal_size()
         if ts == tuple(_cell_size_cache[:2]):
             size = tuple(_cell_size_cache[2:])
-            return None if 0 in size else size
+            return None if 0 in size else geometry.Size(*size)
 
         size = text_area_size = None
 
@@ -408,7 +408,7 @@ def get_cell_size() -> Optional[Tuple[int, int]]:
         )
         _cell_size_cache[:] = ts + size
 
-        return None if 0 in size else size
+        return None if 0 in size else geometry.Size(*size)
 
 
 @cached

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,24 @@
+import pytest
+
+from term_image.geometry import Size
+
+
+class TestSize:
+    def test_args(self):
+        with pytest.raises(TypeError, match="'width'"):
+            Size(2.0, 1)
+        with pytest.raises(TypeError, match="'height'"):
+            Size(1, 2.0)
+
+    def test_tuple(self):
+        size = Size(1, 1)
+        assert isinstance(size, tuple)
+        assert len(size) == 2
+
+    def test_width(self):
+        size = Size(1, -1)
+        assert size[0] == 1 == size.width
+
+    def test_height(self):
+        size = Size(1, -1)
+        assert size[1] == -1 == size.height


### PR DESCRIPTION
- Add `term_image.geometry`.
  - `.geometry.Size`.
- `.utils.get_cell_size()` now returns `.geometry.Size` instances in place of tuples.