### PR TITLE
Static Typing & Type Checking Support

### DIFF
--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: type check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: make install-req
+
+    - name: Type-check with mypy
+      run: make type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `term_image.padding` submodule ([#97]).
   - `Padding`, `AlignedPadding`, `ExactPadding`, etc.
 - Support for Pillow 10. ([8cfebe2])
+- Static Typing & Type Checking Support ([#100]).
 
 ### Changed
 - `term_image.utils.get_cell_size()` now returns `term_image.geometry.Size` instances in place of tuples ([#96]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Support for Python 3.7. ([594d451])
+- Runtime argument type validation ([b790f0e] in [#100]).
 
 
 [#96]: https://github.com/AnonymouX47/term-image/pull/96
 [#97]: https://github.com/AnonymouX47/term-image/pull/97
+[#100]: https://github.com/AnonymouX47/term-image/pull/100
 [497d9b7]: https://github.com/AnonymouX47/term-image/commit/497d9b70dd74605e6589b81bea2fcac22efc684b
 [d296a31]: https://github.com/AnonymouX47/term-image/commit/d296a3110882449f6717959400abbc5fa1bd0891
 [5537037]: https://github.com/AnonymouX47/term-image/commit/5537037a10b1da7ae8467cefaf99dc7959ceb7bc
 [594d451]: https://github.com/AnonymouX47/term-image/commit/594d451d124a47c73a9dce61a4496a2a218261b1
 [8cfebe2]: https://github.com/AnonymouX47/term-image/commit/8cfebe27b63dcdd987fc9d0c71616e76777779a9
+[b790f0e]: https://github.com/AnonymouX47/term-image/commit/b790f0e7c5cd2afd7dafa7c14797136719b9dafb
 
 
 ## [0.7.0] - 2023-06-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,14 +181,30 @@ For a more detailed explanation with examples see the guide at https://cbea.ms/g
 
 - **NAMES tell WHAT... CODE tells HOW... COMMENTS tell WHY, when necessary (and WHAT, when impossible/unreasonable to make it obvious with NAMES)**.
 - Maximum line length is 88 characters.
-- All functions (including methods) should be adequately annotated.
-  - **Note:** Currently, annotations are only for documentation purposes and better/quicker comprehension of the defined interfaces by the users and developers.
 - Try to keep things (definitions, names, dictionary keys, list items, etc)
 
   - **grouped** (preferably by the most dominant criterium e.g object/definition type)
   - **sorted** (preferably lexicographically, with the exception of depended-upon definitions e.g decorators, metaclasses, baseclasses, etc)
 
   wherever **reasonably** possible. Makes things organized and quicker and easier to find 😃.
+
+- All functions (including methods), variables and attributes should be duely type-annotated.
+
+  - Class and instance attributes (public and private) should be explicitly annotated, immediately within the class body.
+  - Module-scope and local variables should be explicitly annotated **only when neccessary**, such as
+
+    - exported/documented module-scope variables,
+    - when the type cannot be [correctly] inferred from the initial value,
+    - it's not initialized immediately, or
+    - the type is too complex or nested to be inferred from the initializer by a human reader at a glance.
+
+  - Any typing construct that incurs a runtime cost (no matter how "little"), such as `typing.cast()`, must not be used anywhere it may be executed more than once.
+  - **Note:**
+
+    - Type annotations are primarily for documentation purposes and better/quicker comprehension of defined interfaces by users and contributors, though they're also required to pass static type checking.
+    - This project doesn't depend primarily on static type checking for correctness. Hence, it is not an alternative to tests.
+
+  - Finally, please do not submit any pull request with code mindlessly written to satisfy a static type checker e.g at an unjustifiable cost of conciseness, readability and/or performance.
 
 - For any matter of style not directly/indirectly addressed here, please try as much as possible to follow formats or styles already established in the project.
 - Any questions or suggestions about the above can be asked or given in [this discussion](https://github.com/AnonymouX47/term-image/discussions/7).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/term_image/py.typed

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,13 @@ py_files := *.py src/ docs/source/conf.py tests/
 
 ## Code Checks
 
-check-code: lint check-format check-imports
+check-code: lint type check-format check-imports
 
 lint:
 	flake8 $(py_files) && echo
+
+type:
+	mypy src/term_image && echo
 
 check-format:
 	black --check --diff --color $(py_files) && echo

--- a/docs/source/api/renderable.rst
+++ b/docs/source/api/renderable.rst
@@ -114,6 +114,14 @@ Exceptions
 
 |
 
+Type Variables and Aliases
+--------------------------
+
+.. autotypevar:: OptionalPaddingT
+   :no-type:
+
+|
+
 Extension API
 -------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx_toolbox.sidebar_links",
     "sphinx_toolbox.more_autosummary",
     "sphinx_toolbox.collapse",
+    "sphinx_toolbox.more_autodoc.typevars",
     "sphinxcontrib.prettyspecialmethods",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.mypy]
 strict = true
 show_column_numbers = true
+implicit_reexport = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,17 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.mypy]
+strict = true
+
+# These modules will go through massive changes real soon
+[[tool.mypy.overrides]]
+module = [
+    'term_image.image.*',
+    'term_image.widget.*',
+]
+ignore_errors = true
+
 [tool.isort]
 profile = "black"
 combine_as_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ build-backend = "setuptools.build_meta"
 [tool.mypy]
 strict = true
 
+[[tool.mypy.overrides]]
+module = [
+    'term_image.renderable.*',
+    'term_image.render.*',
+    'term_image.image.*',
+]
+disable_error_code = ["type-abstract"]
+
 # These modules will go through massive changes real soon
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 strict = true
+show_column_numbers = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==23.9.1
 flake8==6.1.0;python_version>="3.8.1"
 flake8==5.0.4;python_version<"3.8.1"
 isort[colors]==5.12.0
-mypy==1.5.1
+mypy==1.6.0
 pillow==10.0.1
 pytest==7.4.2
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ black==23.9.1
 flake8==6.1.0;python_version>="3.8.1"
 flake8==5.0.4;python_version<"3.8.1"
 isort[colors]==5.12.0
-mypy==1.6.0
+mypy==1.8.0
 pillow==10.0.1
 pytest==7.4.2
 requests==2.31.0
-typing_extensions==4.8.0
+typing_extensions==4.9.0
 urwid==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ black==23.9.1
 flake8==6.1.0;python_version>="3.8.1"
 flake8==5.0.4;python_version<"3.8.1"
 isort[colors]==5.12.0
+mypy==1.5.1
 pillow==10.0.1
 pytest==7.4.2
 requests==2.31.0
+typing_extensions==4.8.0
 urwid==2.2.2

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "requests>=2.23,<3",
         "typing_extensions>=4.8,<5",
     ],
+    include_package_data=True,
     project_urls={
         "Changelog": "https://github.com/AnonymouX47/term-image/blob/main/CHANGELOG.md",
         "Documentation": "https://term-image.readthedocs.io/",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,11 @@ setup(
     license="MIT",
     classifiers=classifiers,
     python_requires=">=3.8",
-    install_requires=["pillow>=9.1,<11", "requests>=2.23,<3"],
+    install_requires=[
+        "pillow>=9.1,<11",
+        "requests>=2.23,<3",
+        "typing_extensions>=4.8,<5",
+    ],
     project_urls={
         "Changelog": "https://github.com/AnonymouX47/term-image/blob/main/CHANGELOG.md",
         "Documentation": "https://term-image.readthedocs.io/",

--- a/src/term_image/__init__.py
+++ b/src/term_image/__init__.py
@@ -23,7 +23,8 @@ __author__ = "Toluwaleke Ogundipe"
 
 from enum import Enum, auto
 from operator import truediv
-from typing import ClassVar, Union
+
+from typing_extensions import ClassVar, Final
 
 from . import utils
 from .exceptions import TermImageError
@@ -35,7 +36,7 @@ __version__ = ".".join(map(str, version_info[:3]))
 if version_info[3:]:
     __version__ += "-" + ".".join(map(str, version_info[3:]))
 
-DEFAULT_QUERY_TIMEOUT: float = utils._query_timeout  # Final[float]
+DEFAULT_QUERY_TIMEOUT: Final[float] = utils._query_timeout
 """Default timeout for :ref:`terminal-queries`
 
 .. seealso:: :py:func:`set_query_timeout`.
@@ -91,7 +92,7 @@ def disable_queries() -> None:
     utils._queries_enabled = False
 
 
-def disable_win_size_swap():
+def disable_win_size_swap() -> None:
     """Disables a workaround for terminal emulators that wrongly report window
     dimensions swapped.
 
@@ -118,13 +119,13 @@ def enable_queries() -> None:
     """
     if not utils._queries_enabled:
         utils._queries_enabled = True
-        utils.get_fg_bg_colors._invalidate_cache()
-        utils.get_terminal_name_version._invalidate_cache()
+        getattr(utils.get_fg_bg_colors, "_invalidate_cache")()
+        getattr(utils.get_terminal_name_version, "_invalidate_cache")()
         with utils._cell_size_lock:
             utils._cell_size_cache[:] = (0,) * 4
 
 
-def enable_win_size_swap():
+def enable_win_size_swap() -> None:
     """Enables a workaround for terminal emulators that wrongly report window
     dimensions swapped.
 
@@ -150,7 +151,7 @@ def get_cell_ratio() -> float:
     return _cell_ratio or truediv(*(utils.get_cell_size() or (1, 2)))
 
 
-def set_cell_ratio(ratio: Union[float, AutoCellRatio]) -> None:
+def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
     """Sets the global :term:`cell ratio`.
 
     Args:
@@ -225,5 +226,5 @@ def set_query_timeout(timeout: float) -> None:
     utils._query_timeout = timeout
 
 
-_cell_ratio = 0.5
+_cell_ratio: float | None = 0.5
 AutoCellRatio.is_supported = None

--- a/src/term_image/__init__.py
+++ b/src/term_image/__init__.py
@@ -166,9 +166,7 @@ def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
             only if the terminal size changes.
 
     Raises:
-        TypeError: An argument is of an inappropriate type.
-        ValueError: An argument is of an appropriate type but has an
-          unexpected/invalid value.
+        ValueError: *ratio* is a non-positive :py:class:`float`.
         term_image.exceptions.TermImageError: Auto cell ratio is not supported
           in the :term:`active terminal` or on the current platform.
 
@@ -200,12 +198,10 @@ def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
             _cell_ratio = truediv(*(utils.get_cell_size() or (1, 2)))
         else:
             _cell_ratio = None
-    elif isinstance(ratio, float):
+    else:
         if ratio <= 0.0:
             raise utils.arg_value_error_range("ratio", ratio)
         _cell_ratio = ratio
-    else:
-        raise utils.arg_type_error("ratio", ratio)
 
 
 def set_query_timeout(timeout: float) -> None:
@@ -215,11 +211,8 @@ def set_query_timeout(timeout: float) -> None:
         timeout: Time limit for awaiting a response from the terminal, in seconds.
 
     Raises:
-        TypeError: *timeout* is not a float.
         ValueError: *timeout* is less than or equal to zero.
     """
-    if not isinstance(timeout, float):
-        raise utils.arg_type_error("timeout", timeout)
     if timeout <= 0.0:
         raise utils.arg_value_error_range("timeout", timeout)
 

--- a/src/term_image/__init__.py
+++ b/src/term_image/__init__.py
@@ -28,6 +28,7 @@ from typing_extensions import ClassVar, Final
 
 from . import utils
 from .exceptions import TermImageError
+from .utils import arg_value_error_range, get_cell_size
 
 version_info = (0, 8, 0, "dev")
 
@@ -148,7 +149,7 @@ def get_cell_ratio() -> float:
     .. seealso:: :py:func:`set_cell_ratio`.
     """
     # `(1, 2)` is a fallback in case the terminal doesn't respond in time
-    return _cell_ratio or truediv(*(utils.get_cell_size() or (1, 2)))
+    return _cell_ratio or truediv(*(get_cell_size() or (1, 2)))
 
 
 def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
@@ -186,7 +187,7 @@ def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
 
     if isinstance(ratio, AutoCellRatio):
         if AutoCellRatio.is_supported is None:
-            AutoCellRatio.is_supported = utils.get_cell_size() is not None
+            AutoCellRatio.is_supported = get_cell_size() is not None
 
         if not AutoCellRatio.is_supported:
             raise TermImageError(
@@ -195,12 +196,12 @@ def set_cell_ratio(ratio: float | AutoCellRatio) -> None:
             )
         elif ratio is AutoCellRatio.FIXED:
             # `(1, 2)` is a fallback in case the terminal doesn't respond in time
-            _cell_ratio = truediv(*(utils.get_cell_size() or (1, 2)))
+            _cell_ratio = truediv(*(get_cell_size() or (1, 2)))
         else:
             _cell_ratio = None
     else:
         if ratio <= 0.0:
-            raise utils.arg_value_error_range("ratio", ratio)
+            raise arg_value_error_range("ratio", ratio)
         _cell_ratio = ratio
 
 
@@ -214,7 +215,7 @@ def set_query_timeout(timeout: float) -> None:
         ValueError: *timeout* is less than or equal to zero.
     """
     if timeout <= 0.0:
-        raise utils.arg_value_error_range("timeout", timeout)
+        raise arg_value_error_range("timeout", timeout)
 
     utils._query_timeout = timeout
 

--- a/src/term_image/ctlseqs.py
+++ b/src/term_image/ctlseqs.py
@@ -7,83 +7,160 @@
 
 from __future__ import annotations
 
-__all__ = []  # Updated later on
+__all__: list[str] = []  # Updated later on
 
 import re
-from typing import Tuple
 
-# Parameters
+# Parameters ===========================================================================
+
 C = "%c"
 Ps = "%d"
 Pt = "%s"
-Pm = lambda n: ";".join((Ps,) * n)  # noqa: E731
+
+
+def Pm(n: int) -> str:
+    return ";".join((Ps,) * n)
+
+
+# ============================ START OF CONTROL SEQUENCES ==============================
 
 _START = None  # Marks the beginning control sequence definitions
 
-# C0
+
+# C0 ===================================================================================
+
 BEL = "\x07"
 ESC = "\x1b"
 
-# C1
+BEL_b: bytes
+ESC_b: bytes
+
+
+# C1 ===================================================================================
+
 APC = f"{ESC}_"
 CSI = f"{ESC}["
 DCS = f"{ESC}P"
 OSC = f"{ESC}]"
 ST = f"{ESC}\\"
 
-# Cursor Movement
+APC_b: bytes
+CSI_b: bytes
+DCS_b: bytes
+OSC_b: bytes
+ST_b: bytes
+
+
+# Functions Beginning With CSI =========================================================
+
+DA1 = f"{CSI}c"
+ERASE_CHARS = f"{CSI}{Ps}X"
+XTVERSION = f"{CSI}>q"
+
+DA1_b: bytes
+ERASE_CHARS_b: bytes
+XTVERSION_b: bytes
+
+# # Cursor Movement ====================================================================
+
 CURSOR_UP = f"{CSI}{Ps}A"
 CURSOR_DOWN = f"{CSI}{Ps}B"
 CURSOR_FORWARD = f"{CSI}{Ps}C"
 CURSOR_BACKWARD = f"{CSI}{Ps}D"
 
-# Select Graphic Rendition
+CURSOR_UP_b: bytes
+CURSOR_DOWN_b: bytes
+CURSOR_FORWARD_b: bytes
+CURSOR_BACKWARD_b: bytes
+
+# # Select Graphic Rendition ===========================================================
+
 SGR_NORMAL = f"{CSI}m"
 SGR_FG_RGB = f"{CSI}38;2;{Pm(3)}m"
 SGR_FG_RGB_2 = f"{CSI}38:2::{Ps}:{Ps}:{Ps}m"
 SGR_BG_RGB = f"{CSI}48;2;{Pm(3)}m"
 SGR_BG_RGB_2 = f"{CSI}48:2::{Ps}:{Ps}:{Ps}m"
 
-# DEC Modes
+SGR_NORMAL_b: bytes
+SGR_FG_RGB_b: bytes
+SGR_FG_RGB_2_b: bytes
+SGR_BG_RGB_b: bytes
+SGR_BG_RGB_2_b: bytes
+
+# # DEC Modes ==========================================================================
+
 DECSET = f"{CSI}?{Ps}h"
 DECRST = f"{CSI}?{Ps}l"
+
+DECSET_b: bytes
+DECRST_b: bytes
 
 SHOW_CURSOR = DECSET % 25
 HIDE_CURSOR = DECRST % 25
 
-# # Terminal Synchronized Output
-# # See https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
+SHOW_CURSOR_b: bytes
+HIDE_CURSOR_b: bytes
+
+# # # Terminal Synchronized Output =====================================================
+# # # See https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
+
 BEGIN_SYNCED_UPDATE = DECSET % 2026
 END_SYNCED_UPDATE = DECRST % 2026
 
-# Window manipulation (XTWINOPS)
+BEGIN_SYNCED_UPDATE_b: bytes
+END_SYNCED_UPDATE_b: bytes
+
+# # Window manipulation (XTWINOPS) =====================================================
+
 XTWINOPS_1 = f"{CSI}{Ps}t"
+
+XTWINOPS_1_b: bytes
 
 TEXT_AREA_SIZE_PX = XTWINOPS_1 % 14
 CELL_SIZE_PX = XTWINOPS_1 % 16
 
-# Text parameters (OSC Ps ; Pt ST)
+TEXT_AREA_SIZE_PX_b: bytes
+CELL_SIZE_PX_b: bytes
+
+
+# Operating System Commands ============================================================
+
+# # Text parameters (OSC Ps ; Pt ST) ===================================================
+
 TEXT_PARAM_SET = f"{OSC}{Ps};{Pt}{ST}"
 TEXT_PARAM_QUERY = f"{OSC}{Ps};?{ST}"
+
+TEXT_PARAM_SET_b: bytes
+TEXT_PARAM_QUERY_b: bytes
 
 TEXT_FG_QUERY = TEXT_PARAM_QUERY % 10
 TEXT_BG_QUERY = TEXT_PARAM_QUERY % 11
 
-# Others
-DA1 = f"{CSI}c"
-ERASE_CHARS = f"{CSI}{Ps}X"
-XTVERSION = f"{CSI}>q"
+TEXT_FG_QUERY_b: bytes
+TEXT_BG_QUERY_b: bytes
 
-# iTerm2 Inline Image Protocol
-# See https://iterm2.com/documentation-images.html
+# # iTerm2 Inline Image Protocol =======================================================
+# # See https://iterm2.com/documentation-images.html
+
 ITERM2_START = f"{OSC}1337;File="
 
-# Kitty Graphics Protocol
-# See https://sw.kovidgoyal.net/kitty/graphics-protocol/
+ITERM2_START_b: bytes
+
+
+# Application Program Commands =========================================================
+
+# # Kitty Graphics Protocol ============================================================
+# # See https://sw.kovidgoyal.net/kitty/graphics-protocol/
+
 KITTY_START = f"{APC}G"
 KITTY_TRANSMISSION = f"{KITTY_START}{Pt};{Pt}{ST}"
 KITTY_DELETE = KITTY_TRANSMISSION % (f"a=d,d={C}", "")
 KITTY_DELETE_EXTRA = KITTY_TRANSMISSION % (f"a=d,d={C},{Pt}", "")
+
+KITTY_START_b: bytes
+KITTY_TRANSMISSION_b: bytes
+KITTY_DELETE_b: bytes
+KITTY_DELETE_EXTRA_b: bytes
 
 KITTY_SUPPORT_QUERY = KITTY_TRANSMISSION % (
     "a=q,t=d,i=31,f=24,s=1,v=1,C=1,c=1,r=1",
@@ -94,14 +171,35 @@ KITTY_DELETE_ALL = KITTY_DELETE % "A"
 KITTY_DELETE_CURSOR = KITTY_DELETE % "C"
 KITTY_DELETE_Z_INDEX = KITTY_DELETE_EXTRA % ("Z", f"z={Ps}")
 
+KITTY_SUPPORT_QUERY_b: bytes
+KITTY_END_CHUNKED_b: bytes
+KITTY_DELETE_ALL_b: bytes
+KITTY_DELETE_CURSOR_b: bytes
+KITTY_DELETE_Z_INDEX_b: bytes
+
+
+# `bytes` Versions of Control Sequences ================================================
 
 module_items = tuple(globals().items())
 for name, value in module_items[module_items.index(("_START", None)) + 1 :]:
     globals()[f"{name}_b"] = value.encode()
     __all__.extend((name, f"{name}_b"))
 
+del _START, module_items
 
-# Patterns for responses to queries
+
+# ============================= END OF CONTROL SEQUENCES ===============================
+
+
+# Patterns For Query Responses =========================================================
+
+RGB_SPEC_re: re.Pattern[str]
+XTVERSION_re: re.Pattern[str]
+TEXT_AREA_SIZE_PX_re: re.Pattern[str]
+CELL_SIZE_PX_re: re.Pattern[str]
+KITTY_RESPONSE_re: re.Pattern[str]
+
+
 class Response:
     CSI_escaped = re.escape(CSI)
     OSC_escaped = re.escape(OSC)
@@ -124,6 +222,11 @@ class Response:
             globals()[name] = re.compile(regex, re.ASCII)
             __all__.append(name)
 
+
+del Response
+
+
+# Other Definitions ====================================================================
 
 __all__ += (
     "cursor_backward",
@@ -150,13 +253,17 @@ def cursor_up(lines: int) -> str:
     return CURSOR_UP % lines if lines > 0 else ""
 
 
-def x_parse_color(spec: str) -> Tuple[int, int, int]:
+def x_parse_color(spec: str) -> tuple[int, int, int]:
     """Converts an RGB device specification according to ``XParseColor``
 
     See the "Color Names" section of the ``XParseColor`` man page.
+
+    NOTE:
+        The older syntax isn't supported.
     """
-    # One hex char -> 4 bits
-    return tuple(int(x, 16) * 255 // ((1 << (len(x) * 4)) - 1) for x in spec.split("/"))
+    rgb = spec.split("/")
+    scale = len(rgb[0]) * 4  # One hex char -> 4 bits
+    uint_scale_max = (1 << scale) - 1
+    r, g, b = [int(component, 16) * 255 // uint_scale_max for component in rgb]
 
-
-del _START, module_items, Response
+    return (r, g, b)

--- a/src/term_image/geometry.py
+++ b/src/term_image/geometry.py
@@ -56,4 +56,4 @@ class Size(RawSize):
             raise arg_value_error_range("height", height)
 
         # Using `tuple` directly instead of `super()` for performance
-        return tuple.__new__(cls, (width, height))  # type: ignore[type-var]
+        return tuple.__new__(cls, (width, height))

--- a/src/term_image/geometry.py
+++ b/src/term_image/geometry.py
@@ -8,6 +8,8 @@ __all__ = ("RawSize", "Size")
 
 from typing import NamedTuple
 
+from typing_extensions import Self
+
 from .utils import arg_value_error_range
 
 
@@ -49,11 +51,11 @@ class Size(RawSize):
 
     __slots__ = ()
 
-    def __new__(cls, width: int, height: int):
+    def __new__(cls, width: int, height: int) -> Self:
         if width < 1:
             raise arg_value_error_range("width", width)
         if height < 1:
             raise arg_value_error_range("height", height)
 
         # Using `tuple` directly instead of `super()` for performance
-        return tuple.__new__(cls, (width, height))  # type: ignore
+        return tuple.__new__(cls, (width, height))  # type: ignore[type-var]

--- a/src/term_image/geometry.py
+++ b/src/term_image/geometry.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 
 __all__ = ("RawSize", "Size")
 
-from typing import NamedTuple
-
-from typing_extensions import Self
+from typing_extensions import NamedTuple, Self
 
 from .utils import arg_value_error_range
 

--- a/src/term_image/padding.py
+++ b/src/term_image/padding.py
@@ -121,7 +121,8 @@ class Padding(metaclass=ABCMeta):
     # Special Methods ==========================================================
 
     def __init__(self, fill: str = " ") -> None:
-        __class__.__setattr__(self, "fill", fill)  # Subclasses are to be "immutable"
+        # Subclasses are to be "immutable", `super()` is costlier
+        __class__.__setattr__(self, "fill", fill)  # type: ignore[name-defined]
 
     # Public Methods ===========================================================
 
@@ -346,7 +347,7 @@ class AlignedPadding(Padding):
         if self.relative:
             raise RelativePaddingDimensionError("Relative minimum render dimension(s)")
 
-        return Size(*map(max, (self.width, self.height), render_size))  # type: ignore
+        return Size(max(self.width, render_size[0]), max(self.height, render_size[1]))
 
     def resolve(self, terminal_size: os.terminal_size) -> AlignedPadding:
         """Resolves **relative** *minimum render dimensions*.
@@ -466,12 +467,12 @@ class ExactPadding(Padding):
         GET:
             Returns the padding dimensions, ``(left, top, right, bottom)``.
         """
-        return astuple(self)[:4]  # type: ignore
+        return astuple(self)[:4]  # type: ignore[return-value]
 
     # Extension methods ========================================================
 
     def _get_exact_dimensions_(self, render_size: Size) -> tuple[int, int, int, int]:
-        return astuple(self)[:4]  # type: ignore
+        return astuple(self)[:4]  # type: ignore[return-value]
 
 
 # Exceptions ===================================================================

--- a/src/term_image/padding.py
+++ b/src/term_image/padding.py
@@ -123,7 +123,7 @@ class Padding(metaclass=ABCMeta):
 
     def __init__(self, fill: str = " ") -> None:
         # Subclasses are to be "immutable", `super()` is costlier
-        __class__.__setattr__(self, "fill", fill)  # type: ignore[name-defined]
+        Padding.__setattr__(self, "fill", fill)
 
     # Public Methods ===========================================================
 

--- a/src/term_image/padding.py
+++ b/src/term_image/padding.py
@@ -19,6 +19,8 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import astuple, dataclass
 from enum import IntEnum, auto
 
+from typing_extensions import override
+
 from .exceptions import TermImageError
 from .geometry import RawSize, Size
 from .utils import arg_value_error_range
@@ -336,6 +338,7 @@ class AlignedPadding(Padding):
 
     # Public Methods ===========================================================
 
+    @override
     def get_padded_size(self, render_size: Size) -> Size:
         """Computes an expected padded :term:`render size`.
 
@@ -373,6 +376,7 @@ class AlignedPadding(Padding):
 
     # Extension methods ========================================================
 
+    @override
     def _get_exact_dimensions_(self, render_size: Size) -> tuple[int, int, int, int]:
         if self.relative:
             raise RelativePaddingDimensionError("Relative minimum render dimension(s)")
@@ -471,6 +475,7 @@ class ExactPadding(Padding):
 
     # Extension methods ========================================================
 
+    @override
     def _get_exact_dimensions_(self, render_size: Size) -> tuple[int, int, int, int]:
         return astuple(self)[:4]  # type: ignore[return-value]
 

--- a/src/term_image/padding.py
+++ b/src/term_image/padding.py
@@ -476,13 +476,13 @@ class ExactPadding(Padding):
         GET:
             Returns the padding dimensions, ``(left, top, right, bottom)``.
         """
-        return astuple(self)[:4]  # type: ignore[return-value]
+        return astuple(self)[:4]
 
     # Extension methods ========================================================
 
     @override
     def _get_exact_dimensions_(self, render_size: Size) -> tuple[int, int, int, int]:
-        return astuple(self)[:4]  # type: ignore[return-value]
+        return astuple(self)[:4]
 
 
 # Exceptions ===================================================================

--- a/src/term_image/render/_iterator.py
+++ b/src/term_image/render/_iterator.py
@@ -24,7 +24,6 @@ from ..renderable import (
     Seek,
 )
 from ..utils import (
-    arg_type_error,
     arg_value_error,
     arg_value_error_msg,
     arg_value_error_range,
@@ -67,7 +66,6 @@ class RenderIterator:
             :py:class:`~term_image.renderable.FrameCount.INDEFINITE` frame count.
 
     Raises:
-        TypeError: An argument is of an inappropriate type.
         ValueError: An argument is of an appropriate type but has an
           unexpected/invalid value.
         IncompatibleRenderArgsError: Incompatible render arguments.
@@ -207,7 +205,6 @@ class RenderIterator:
 
         Raises:
             FinalizedIteratorError: The iterator has been finalized.
-            TypeError: An argument is of an inappropriate type.
             ValueError: *offset* is out of range.
 
         The value range for *offset* depends on the
@@ -327,8 +324,6 @@ class RenderIterator:
         """
         if self._closed:
             raise FinalizedIteratorError("This iterator has been finalized") from None
-        if not isinstance(offset, int):
-            raise arg_type_error("offset", offset)
 
         frame_count = self._renderable.frame_count
         renderable_data = self._renderable_data
@@ -389,16 +384,12 @@ class RenderIterator:
 
         Raises:
             FinalizedIteratorError: The iterator has been finalized.
-            TypeError: An argument is of an inappropriate type.
 
         NOTE:
             Takes effect from the next [#ri-nf]_ rendered frame.
         """
         if self._closed:
             raise FinalizedIteratorError("This iterator has been finalized") from None
-
-        if not isinstance(padding, Padding):
-            raise arg_type_error("padding", padding)
 
         self._padding = (
             padding.resolve(get_terminal_size())
@@ -415,7 +406,6 @@ class RenderIterator:
 
         Raises:
             FinalizedIteratorError: The iterator has been finalized.
-            TypeError: An argument is of an inappropriate type.
             IncompatibleRenderArgsError: Incompatible render arguments.
 
         NOTE:
@@ -423,9 +413,6 @@ class RenderIterator:
         """
         if self._closed:
             raise FinalizedIteratorError("This iterator has been finalized") from None
-
-        if not isinstance(render_args, RenderArgs):
-            raise arg_type_error("render_args", render_args)
 
         render_cls = type(self._renderable)
         self._render_args = (
@@ -443,16 +430,12 @@ class RenderIterator:
 
         Raises:
             FinalizedIteratorError: The iterator has been finalized.
-            TypeError: An argument is of an inappropriate type.
 
         NOTE:
             Takes effect from the next [#ri-nf]_ rendered frame.
         """
         if self._closed:
             raise FinalizedIteratorError("This iterator has been finalized") from None
-
-        if not isinstance(render_size, Size):
-            raise arg_type_error("render_size", render_size)
 
         self._renderable_data.size = render_size
         self._padded_size = self._padding.get_padded_size(render_size)
@@ -491,8 +474,6 @@ class RenderIterator:
         new = cls.__new__(cls)
         new._init(renderable, render_args, padding, *args, **kwargs)
 
-        if not isinstance(render_data, RenderData):
-            raise arg_type_error("render_data", render_data)
         if render_data.render_cls is not type(renderable):
             raise arg_value_error_msg(
                 "Invalid render data for renderable of type "
@@ -507,9 +488,6 @@ class RenderIterator:
         if not (render_args and render_args.render_cls is type(renderable)):
             # Validate compatibility (and convert, if compatible)
             render_args = RenderArgs(type(renderable), render_args)
-
-        if not isinstance(finalize, bool):
-            raise arg_type_error("finalize", finalize)
 
         new._padding = (
             padding.resolve(get_terminal_size())
@@ -536,24 +514,10 @@ class RenderIterator:
 
         Performs the part of the initialization common to all constructors.
         """
-        if not isinstance(renderable, Renderable):
-            raise arg_type_error("renderable", renderable)
         if not renderable.animated:
             raise arg_value_error_msg("'renderable' is not animated", renderable)
-
-        if render_args and not isinstance(render_args, RenderArgs):
-            raise arg_type_error("render_args", render_args)
-
-        if not isinstance(padding, Padding):
-            raise arg_type_error("padding", padding)
-
-        if not isinstance(loops, int):
-            raise arg_type_error("loops", loops)
         if not loops:
             raise arg_value_error("loops", loops)
-
-        if not isinstance(cache, int):  # `bool` is a subclass of `int`
-            raise arg_type_error("cache", cache)
         if False is not cache <= 0:
             raise arg_value_error_range("cache", cache)
 

--- a/src/term_image/render/_iterator.py
+++ b/src/term_image/render/_iterator.py
@@ -501,7 +501,7 @@ class RenderIterator:
             )
         if render_data.finalized:
             raise ValueError("The render data has been finalized")
-        if not render_data[Renderable].iteration:  # type: ignore[type-abstract]
+        if not render_data[Renderable].iteration:
             raise arg_value_error_msg("Invalid render data for iteration", render_data)
 
         if not (render_args and render_args.render_cls is type(renderable)):
@@ -579,9 +579,7 @@ class RenderIterator:
         self._render_data = render_data
         self._render_args = render_args
         renderable_data: RenderableData
-        self._renderable_data = renderable_data = render_data[
-            Renderable  # type: ignore[type-abstract]
-        ]
+        self._renderable_data = renderable_data = render_data[Renderable]
         self._padded_size = self._padding.get_padded_size(renderable_data.size)
 
         # Setup

--- a/src/term_image/render/_iterator.py
+++ b/src/term_image/render/_iterator.py
@@ -66,8 +66,7 @@ class RenderIterator:
             :py:class:`~term_image.renderable.FrameCount.INDEFINITE` frame count.
 
     Raises:
-        ValueError: An argument is of an appropriate type but has an
-          unexpected/invalid value.
+        ValueError: An argument has an invalid value.
         IncompatibleRenderArgsError: Incompatible render arguments.
 
     The iterator yields a :py:class:`~term_image.renderable.Frame` instance on every

--- a/src/term_image/render/_iterator.py
+++ b/src/term_image/render/_iterator.py
@@ -529,7 +529,8 @@ class RenderIterator:
             False
             if indefinite
             else cache
-            if isinstance(cache, bool)
+            # `isinstance` is much costlier on failure and `bool` cannot be subclassed
+            if type(cache) is bool
             else renderable.frame_count <= cache  # type: ignore[operator]
         )
 

--- a/src/term_image/renderable/__init__.py
+++ b/src/term_image/renderable/__init__.py
@@ -31,6 +31,7 @@ __all__ = (
     "UninitializedDataFieldError",
     "UnknownArgsFieldError",
     "UnknownDataFieldError",
+    "OptionalPaddingT",
 )
 
 from ._enum import FrameCount, FrameDuration, Seek
@@ -41,7 +42,7 @@ from ._exceptions import (
     RenderError,
     RenderSizeOutofRangeError,
 )
-from ._renderable import Renderable, RenderableData
+from ._renderable import OptionalPaddingT, Renderable, RenderableData
 from ._types import (
     ArgsNamespace,
     DataNamespace,

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -18,6 +18,7 @@ import term_image
 
 from .. import geometry
 from ..ctlseqs import HIDE_CURSOR, SHOW_CURSOR, cursor_down, cursor_forward, cursor_up
+from ..geometry import Size
 from ..padding import AlignedPadding, ExactPadding, Padding
 from ..utils import arg_type_error, arg_value_error_range, get_terminal_size
 from . import _types
@@ -750,9 +751,8 @@ been initialized
         """
         from term_image.render import RenderIterator
 
-        width, height = render_size = render_data[
-            Renderable  # type: ignore[type-abstract]
-        ].size
+        render_size: Size = render_data[Renderable].size  # type: ignore[type-abstract]
+        height = render_size.height
         pad_left, _, _, pad_bottom = padding._get_exact_dimensions_(render_size)
         render_iter = RenderIterator._from_render_data_(
             self,
@@ -975,7 +975,9 @@ been initialized
             :py:meth:`~term_image.renderable.Renderable._init_render_`.
         """
         render_data = RenderData(type(self))
-        renderable_data = render_data[Renderable]  # type: ignore[type-abstract]
+        renderable_data: RenderableData = render_data[
+            Renderable  # type: ignore[type-abstract]
+        ]
         renderable_data.update(
             size=self._get_render_size_(),
             frame_offset=self.__frame,
@@ -1146,7 +1148,7 @@ been initialized
                 padding = padding.resolve(terminal_size)
 
             if check_size:
-                render_size = render_data[
+                render_size: Size = render_data[
                     Renderable  # type: ignore[type-abstract]
                 ].size
                 width, height = (

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -751,7 +751,7 @@ been initialized
         """
         from term_image.render import RenderIterator
 
-        render_size: Size = render_data[Renderable].size  # type: ignore[type-abstract]
+        render_size: Size = render_data[Renderable].size
         height = render_size.height
         pad_left, _, _, pad_bottom = padding._get_exact_dimensions_(render_size)
         render_iter = RenderIterator._from_render_data_(
@@ -975,9 +975,7 @@ been initialized
             :py:meth:`~term_image.renderable.Renderable._init_render_`.
         """
         render_data = RenderData(type(self))
-        renderable_data: RenderableData = render_data[
-            Renderable  # type: ignore[type-abstract]
-        ]
+        renderable_data: RenderableData = render_data[Renderable]
         renderable_data.update(
             size=self._get_render_size_(),
             frame_offset=self.__frame,
@@ -1148,9 +1146,7 @@ been initialized
                 padding = padding.resolve(terminal_size)
 
             if check_size:
-                render_size: Size = render_data[
-                    Renderable  # type: ignore[type-abstract]
-                ].size
+                render_size: Size = render_data[Renderable].size
                 width, height = (
                     padding.get_padded_size(render_size) if padding else render_size
                 )
@@ -1238,7 +1234,7 @@ been initialized
 # NOTE: The position of these is critical, as they're required for the
 # creation of render argument and data namespace classes.
 _types.RenderableMeta = RenderableMeta  # type: ignore[attr-defined]
-_types.BASE_RENDER_ARGS.__init__(Renderable)  # type: ignore[misc]
+RenderArgs.__init__(_types.BASE_RENDER_ARGS, Renderable)
 
 
 class RenderableData(DataNamespace, render_cls=Renderable):

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -124,8 +124,7 @@ class Renderable(metaclass=RenderableMeta, _base=True):
           i.e the renderable is non-animated.
 
     Raises:
-        ValueError: An argument is of an appropriate type but has an
-          unexpected/invalid value.
+        ValueError: An argument has an invalid value.
 
     ATTENTION:
         This is an abstract base class. Hence, only **concrete** subclasses can be

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = ("Renderable", "RenderableData")
+__all__ = ("Renderable", "RenderableData", "OptionalPaddingT")
 
 import sys
 from abc import ABCMeta, abstractmethod

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -20,7 +20,7 @@ from .. import geometry
 from ..ctlseqs import HIDE_CURSOR, SHOW_CURSOR, cursor_down, cursor_forward, cursor_up
 from ..geometry import Size
 from ..padding import AlignedPadding, ExactPadding, Padding
-from ..utils import arg_type_error, arg_value_error_range, get_terminal_size
+from ..utils import arg_value_error_range, get_terminal_size
 from . import _types
 from ._enum import FrameCount, FrameDuration, Seek
 from ._exceptions import (
@@ -124,7 +124,6 @@ class Renderable(metaclass=RenderableMeta, _base=True):
           i.e the renderable is non-animated.
 
     Raises:
-        TypeError: An argument is of an inappropriate type.
         ValueError: An argument is of an appropriate type but has an
           unexpected/invalid value.
 
@@ -350,19 +349,12 @@ been initialized
         frame_count: int | FrameCount,
         frame_duration: int | FrameDuration,
     ) -> None:
-        if isinstance(frame_count, int):
-            if frame_count < 1:
-                raise arg_value_error_range("frame_count", frame_count)
-        elif not isinstance(frame_count, FrameCount):
-            raise arg_type_error("frame_count", frame_count)
+        if isinstance(frame_count, int) and frame_count < 1:
+            raise arg_value_error_range("frame_count", frame_count)
 
         if frame_count != 1:
-            if isinstance(frame_duration, int):
-                if frame_duration <= 0:
-                    raise arg_value_error_range("frame_duration", frame_duration)
-            elif not isinstance(frame_duration, FrameDuration):
-                raise arg_type_error("frame_duration", frame_duration)
-
+            if isinstance(frame_duration, int) and frame_duration <= 0:
+                raise arg_value_error_range("frame_duration", frame_duration)
             self.__frame_duration = frame_duration
 
         self.animated = frame_count != 1
@@ -456,11 +448,8 @@ been initialized
                 "Cannot set frame duration for a non-animated renderable"
             )
 
-        if isinstance(duration, int):
-            if duration <= 0:
-                raise arg_value_error_range("frame_duration", duration)
-        elif not isinstance(duration, FrameDuration):
-            raise arg_type_error("frame_duration", duration)
+        if isinstance(duration, int) and duration <= 0:
+            raise arg_value_error_range("frame_duration", duration)
 
         self.__frame_duration = duration
 
@@ -514,7 +503,6 @@ been initialized
                    therefore, the output (especially for animations).
 
         Raises:
-            TypeError: An argument is of an inappropriate type.
             RenderSizeOutofRangeError: The padded :term:`render size` can not fit into
               the :term:`terminal size`.
             IncompatibleRenderArgsError: Incompatible render arguments.
@@ -536,20 +524,6 @@ been initialized
               looped but can be terminated with :py:data:`~signal.SIGINT`
               (``CTRL + C``), **without** raising :py:class:`KeyboardInterrupt`.
         """
-        if render_args and not isinstance(render_args, RenderArgs):
-            raise arg_type_error("render_args", render_args)
-        if not isinstance(padding, Padding):
-            raise arg_type_error("padding", padding)
-        if self.animated and not isinstance(animate, bool):
-            raise arg_type_error("animate", animate)
-
-        # Validation of *loops* and *cache* is delegated to `RenderIterator`.
-
-        if not isinstance(check_size, bool):
-            raise arg_type_error("check_size", check_size)
-        if not isinstance(allow_scroll, bool):
-            raise arg_type_error("allow_scroll", allow_scroll)
-
         animation = self.animated and animate
         output = sys.stdout
         not_echo_input = OS_IS_UNIX and not echo_input and output.isatty()
@@ -623,15 +597,9 @@ been initialized
             The rendered frame.
 
         Raises:
-            TypeError: An argument is of an inappropriate type.
             IncompatibleRenderArgsError: Incompatible render arguments.
             RenderError: An error occurred during :term:`rendering`.
         """
-        if render_args and not isinstance(render_args, RenderArgs):
-            raise arg_type_error("render_args", render_args)
-        if not isinstance(padding, Padding):
-            raise arg_type_error("padding", padding)
-
         frame, padding = self._init_render_(self._render_, render_args, padding)
         padded_size = padding.get_padded_size(frame.render_size)
 
@@ -659,7 +627,6 @@ been initialized
         Raises:
             IndefiniteSeekError: The renderable has
               :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` frame count.
-            TypeError: An argument is of an inappropriate type.
             ValueError: *offset* is out of range.
 
         The value range for *offset* depends on *whence*:
@@ -685,8 +652,6 @@ been initialized
             raise IndefiniteSeekError(
                 "Cannot seek a renderable with INDEFINITE frame count"
             )
-        if not isinstance(offset, int):
-            raise arg_type_error("offset", offset)
 
         frame = (
             offset

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -532,7 +532,7 @@ been initialized
         render_data: RenderData
         real_render_args: RenderArgs
         (render_data, real_render_args), padding = self._init_render_(
-            lambda *args: args,  # type: ignore[arg-type]
+            lambda *args: args,
             render_args,
             padding,
             iteration=animation,

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -35,6 +35,7 @@ from typing_extensions import (
     Never,
     Self,
     TypeVar,
+    dataclass_transform,
 )
 
 from .. import geometry
@@ -300,6 +301,7 @@ class ArgsNamespaceMeta(ArgsDataNamespaceMeta):
         return args_cls
 
 
+@dataclass_transform(eq_default=True, frozen_default=True)
 class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta, _base=True):
     """ArgsNamespace(*values, **fields)
 
@@ -377,7 +379,7 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta, _base=True):
             f"{type(self)._RENDER_CLS.__name__!r}"
         )
 
-    def __setattr__(self, name: str, value: Any) -> Never:
+    def __setattr__(self, name: str, value: Never) -> Never:
         raise AttributeError(
             "Cannot modify render argument fields, use the `update()` method "
             "of the namespace or the containing `RenderArgs` instance, as "

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -137,7 +137,7 @@ class ArgsDataNamespaceMeta(type):
     """Metaclass of render argument/data namespaces."""
 
     _associated: bool = False
-    _FIELDS: MappingProxyType[str, None] = MappingProxyType({})
+    _FIELDS: MappingProxyType[str, Any] = MappingProxyType({})
     _RENDER_CLS: type[Renderable]
 
     def __new__(
@@ -216,7 +216,7 @@ class ArgsDataNamespace(metaclass=ArgsDataNamespaceMeta, _base=True):
     """:term:`Render class`\\ -specific argument/data namespace."""
 
     _associated: ClassVar[bool]
-    _FIELDS: ClassVar[MappingProxyType[str, None]]
+    _FIELDS: ClassVar[MappingProxyType[str, Any]]
     _RENDER_CLS: ClassVar[type[Renderable]]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
@@ -259,8 +259,6 @@ class ArgsDataNamespace(metaclass=ArgsDataNamespaceMeta, _base=True):
 
 class ArgsNamespaceMeta(ArgsDataNamespaceMeta):
     """Metaclass of render argument namespaces."""
-
-    _FIELDS: MappingProxyType[str, Any]
 
     def __new__(
         cls: type[ArgsNamespaceMetaT],
@@ -335,8 +333,6 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta, _base=True):
 
     .. Completed in /docs/source/api/renderable.rst
     """
-
-    _FIELDS: ClassVar[MappingProxyType[str, Any]]
 
     def __init__(self, *values: Any, **fields: Any) -> None:
         default_fields = type(self)._FIELDS
@@ -601,6 +597,8 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta, _base=True):
 class DataNamespaceMeta(ArgsDataNamespaceMeta):
     """Metaclass of render data namespaces."""
 
+    _FIELDS: MappingProxyType[str, None]
+
     def __new__(
         cls: type[DataNamespaceMetaT],
         name: str,
@@ -656,6 +654,8 @@ class DataNamespace(ArgsDataNamespace, metaclass=DataNamespaceMeta, _base=True):
 
     .. Completed in /docs/source/api/renderable.rst
     """
+
+    _FIELDS: ClassVar[MappingProxyType[str, None]]
 
     def __init__(self) -> None:
         pass

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -1056,6 +1056,20 @@ class RenderArgs(RenderArgsData):
             TypeError: An argument is of an inappropriate type.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
             NoArgsNamespaceError: *render_cls* has no render arguments.
+
+        NOTE:
+            The return type hint is :py:class:`~typing.Any` only for compatibility
+            with static type checking, as this aspect of the interface seems too
+            dynamic to be correctly expressed with the exisiting type system.
+
+            Regardless, the return value is guaranteed to always be an instance
+            of a render argument namespace class associated with *render_cls*.
+            For instance, the following would always be valid for
+            :py:class:`~term_image.renderable.Renderable`::
+
+               renderable_args: RenderableArgs = render_args[Renderable]
+
+            and similar idioms are encouraged to be used for other render classes.
         """
         try:
             return self._namespaces[render_cls]
@@ -1294,6 +1308,20 @@ class RenderData(RenderArgsData):
             TypeError: An argument is of an inappropriate type.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
             NoDataNamespaceError: *render_cls* has no render data.
+
+        NOTE:
+            The return type hint is :py:class:`~typing.Any` only for compatibility
+            with static type checking, as this aspect of the interface seems too
+            dynamic to be correctly expressed with the exisiting type system.
+
+            Regardless, the return value is guaranteed to always be an instance
+            of a render data namespace class associated with *render_cls*.
+            For instance, the following would always be valid for
+            :py:class:`~term_image.renderable.Renderable`::
+
+               renderable_data: RenderableData = render_data[Renderable]
+
+            and similar idioms are encouraged to be used for other render classes.
         """
         try:
             return self._namespaces[render_cls]

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -1139,11 +1139,11 @@ class RenderArgs(RenderArgsData):
             raise arg_type_error("render_cls", render_cls)
 
         if issubclass(render_cls, self.render_cls):
-            return type(self)(render_cls, self)
+            return RenderArgs(render_cls, self)
 
         if issubclass(self.render_cls, render_cls):
             render_cls_args_mro = render_cls._ALL_DEFAULT_ARGS
-            return type(self)(
+            return RenderArgs(
                 render_cls,
                 *[
                     namespace
@@ -1219,7 +1219,7 @@ class RenderArgs(RenderArgsData):
                 "Invalid type for the first argument", render_cls_or_namespace
             )
 
-        return type(self)(
+        return RenderArgs(
             self.render_cls,
             self,
             *((self[render_cls].update(**fields),) if render_cls else namespaces),

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -36,6 +36,7 @@ from typing_extensions import (
     Self,
     TypeVar,
     dataclass_transform,
+    overload,
 )
 
 from .. import geometry
@@ -1173,9 +1174,28 @@ class RenderArgs(RenderArgsData):
             f"{self.render_cls.__name__!r}"
         )
 
+    @overload
+    def update(
+        self,
+        namespace: ArgsNamespace,
+        /,
+        *namespaces: ArgsNamespace,
+    ) -> RenderArgs:
+        ...
+
+    @overload
+    def update(
+        self,
+        render_cls: type[Renderable],
+        /,
+        **fields: Any,
+    ) -> RenderArgs:
+        ...
+
     def update(
         self,
         render_cls_or_namespace: type[Renderable] | ArgsNamespace,
+        /,
         *namespaces: ArgsNamespace,
         **fields: Any,
     ) -> RenderArgs:
@@ -1185,6 +1205,7 @@ class RenderArgs(RenderArgsData):
         Replaces or updates render argument namespaces.
 
         Args:
+            namespace (ArgsNamespace): Prepended to *namespaces*.
             namespaces: Render argument namespaces compatible [#ran2]_ with
               :py:attr:`render_cls`.
 

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -27,9 +27,18 @@ from inspect import Parameter, signature
 from types import MappingProxyType
 from typing import Any, ClassVar, Iterator, Mapping, NamedTuple, Sequence, Type
 
+from typing_extensions import TYPE_CHECKING
+
 from .. import geometry
 from ..utils import arg_type_error, arg_type_error_msg
 from ._exceptions import RenderableError
+
+if TYPE_CHECKING:
+    # `RenderableMeta` is set from `._renderable` later on, as a top-level import
+    # will result in a circular import and localized imports are just unnecessarily
+    # costly (no matter how minimal).
+    from ._renderable import Renderable, RenderableMeta
+
 
 # Exceptions ===================================================================
 
@@ -1292,7 +1301,3 @@ class RenderData(RenderArgsData):
 # Variables ====================================================================
 
 BASE_RENDER_ARGS = RenderArgs.__new__(RenderArgs, None)
-
-# Updated from `._renderable`
-Renderable = "Renderable"
-RenderableMeta = "RenderableMeta"

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -976,7 +976,7 @@ class RenderArgs(RenderArgsData):
             namespaces_dict.update(init_render_args._namespaces)
 
         for index, namespace in enumerate(namespaces):
-            if namespace._RENDER_CLS not in render_cls._ALL_DEFAULT_ARGS:
+            if namespace._RENDER_CLS not in namespaces_dict:
                 raise IncompatibleArgsNamespaceError(
                     f"'namespaces[{index}]' (associated with "
                     f"{namespace._RENDER_CLS.__name__!r}) is incompatible with "
@@ -1037,7 +1037,7 @@ class RenderArgs(RenderArgsData):
             The constituent namespace associated with *render_cls*.
 
         Raises:
-            TypeError: An argument is of an inappropriate type.
+            TypeError: *render_cls* is not a render class.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
             NoArgsNamespaceError: *render_cls* has no render arguments.
 
@@ -1057,7 +1057,9 @@ class RenderArgs(RenderArgsData):
         """
         try:
             return self._namespaces[render_cls]
-        except (TypeError, KeyError):
+        except TypeError:
+            raise arg_type_error("render_cls", render_cls) from None
+        except KeyError:
             if not isinstance(render_cls, RenderableMeta):
                 raise arg_type_error("render_cls", render_cls) from None
 
@@ -1300,7 +1302,7 @@ class RenderData(RenderArgsData):
             The constituent namespace associated with *render_cls*.
 
         Raises:
-            TypeError: An argument is of an inappropriate type.
+            TypeError: *render_cls* is not a render class.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
             NoDataNamespaceError: *render_cls* has no render data.
 
@@ -1320,7 +1322,9 @@ class RenderData(RenderArgsData):
         """
         try:
             return self._namespaces[render_cls]
-        except (TypeError, KeyError):
+        except TypeError:
+            raise arg_type_error("render_cls", render_cls) from None
+        except KeyError:
             if not isinstance(render_cls, RenderableMeta):
                 raise arg_type_error("render_cls", render_cls) from None
 

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -353,7 +353,11 @@ def clear_queue(queue: Queue[Any] | mp_Queue[Any]) -> None:
 
 
 def color(
-    text: str, fg: Tuple[int] = (), bg: Tuple[int] = (), *, end: bool = False
+    text: str,
+    fg: tuple[int, int, int] | None = None,
+    bg: tuple[int, int, int] | None = None,
+    *,
+    end: bool = False,
 ) -> str:
     """Prepends *text* with direct-color escape sequences for the given foreground
     and/or background RGB values, optionally ending with the color reset sequence.
@@ -370,8 +374,8 @@ def color(
     The color code is omitted for any of *fg* or *bg* that is empty.
     """
     return (ctlseqs.SGR_FG_RGB * bool(fg) + ctlseqs.SGR_BG_RGB * bool(bg) + "%s") % (
-        *fg,
-        *bg,
+        *(fg or ()),
+        *(bg or ()),
         text,
     ) + ctlseqs.SGR_NORMAL * end
 

--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -17,6 +17,7 @@ import os
 import sys
 import warnings
 from array import array
+from collections.abc import Callable
 from functools import wraps
 from multiprocessing import Array, Process, Queue as mp_Queue, RLock as mp_RLock
 from operator import floordiv
@@ -24,8 +25,8 @@ from queue import Empty, Queue
 from shutil import get_terminal_size as _get_terminal_size
 from threading import RLock
 from time import monotonic
-from types import FunctionType
-from typing import Any, Callable, Optional, Tuple, Union
+
+from typing_extensions import Any, Literal, ParamSpec, TypeVar, no_type_check, overload
 
 import term_image
 
@@ -47,31 +48,38 @@ else:
 # NOTE: Any cached feature using a query should have it's cache invalidated in
 # `term_image.enable_queries()`.
 
+# Type Variables and Aliases
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
 # Decorator Classes
 
 
-class ClassInstanceMethod(classmethod):
+class ClassInstanceMethod(classmethod):  # type: ignore[type-arg]
     """A method which when invoked via the owner, behaves like a class method
     and when invoked via an instance, behaves like an instance method.
     """
 
-    def __init__(
-        self, f_owner: FunctionType, f_instance: Optional[FunctionType] = None
-    ):
+    @no_type_check  # This definition is to be removed soon
+    def __init__(self, f_owner, f_instance=None):
         super().__init__(f_owner)
         self.f_owner = f_owner
         self.f_instance = f_instance
 
+    @no_type_check  # This definition is to be removed soon
     def __get__(self, instance, owner=None):
         if instance:
             return self.f_instance.__get__(instance, owner)
         else:
             return super().__get__(instance, owner)
 
-    def classmethod(self, function: FunctionType) -> ClassInstanceMethod:
+    @no_type_check  # This definition is to be removed soon
+    def classmethod(self, function):
         return type(self)(function, self.f_instance)
 
-    def instancemethod(self, function: FunctionType) -> ClassInstanceMethod:
+    @no_type_check  # This definition is to be removed soon
+    def instancemethod(self, function):
         return type(self)(self.f_owner, function)
 
 
@@ -80,6 +88,7 @@ class ClassPropertyBase(property):
     instance.
     """
 
+    @no_type_check  # This definition is to be removed soon
     def __init__(self, fget=None, fset=None, fdel=None, doc=None):
         super().__init__(fget, fset, fdel, doc)
         # `property` doesn't set `__doc__`, probably cos the subclass' `__doc__`
@@ -108,7 +117,7 @@ class ClassProperty(ClassPropertyBase):
 # Decorator Functions
 
 
-def no_redecorate(decor: FunctionType) -> FunctionType:
+def no_redecorate(decor: Callable[P, T]) -> Callable[P, T]:
     """Prevents a decorator from re-decorating objects.
 
     Args:
@@ -118,18 +127,19 @@ def no_redecorate(decor: FunctionType) -> FunctionType:
         return decor
 
     @wraps(decor)
-    def no_redecorate_wrapper(obj, *args, **kwargs):
-        if not getattr(obj, f"_{decor.__name__}_", False):
-            obj = decor(obj, *args, **kwargs)
+    def no_redecorate_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        if not getattr(args[0], f"_{decor.__name__}_", False):
+            obj = decor(*args, **kwargs)
             setattr(obj, f"_{decor.__name__}_", True)
         return obj
 
-    no_redecorate_wrapper._no_redecorate_ = True
+    setattr(no_redecorate_wrapper, "_no_redecorate_", True)
+
     return no_redecorate_wrapper
 
 
 @no_redecorate
-def cached(func: FunctionType) -> FunctionType:
+def cached(func: Callable[P, T]) -> Callable[P, T]:
     """Enables return value caching.
 
     Args:
@@ -147,7 +157,7 @@ def cached(func: FunctionType) -> FunctionType:
     """
 
     @wraps(func)
-    def cached_wrapper(*args, **kwargs):
+    def cached_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         arguments = (args, tuple(kwargs.items()))
         with lock:
             try:
@@ -155,19 +165,19 @@ def cached(func: FunctionType) -> FunctionType:
             except KeyError:
                 return cache.setdefault(arguments, func(*args, **kwargs))
 
-    def invalidate():
+    def invalidate() -> None:
         with lock:
             cache.clear()
 
-    cache = {}
+    cache: dict[tuple[P.args, tuple[tuple[str, Any], ...]], T] = {}
     lock = RLock()
-    cached_wrapper._invalidate_cache = invalidate
+    setattr(cached_wrapper, "_invalidate_cache", invalidate)
 
     return cached_wrapper
 
 
 @no_redecorate
-def lock_tty(func: FunctionType) -> FunctionType:
+def lock_tty(func: Callable[P, T]) -> Callable[P, T]:
     """Synchronizes access to the :term:`active terminal`.
 
     Args:
@@ -193,7 +203,7 @@ def lock_tty(func: FunctionType) -> FunctionType:
     """
 
     @wraps(func)
-    def lock_tty_wrapper(*args, **kwargs):
+    def lock_tty_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         # If a thread reaches this point while the lock is being changed
         # (the old lock has been acquired but hasn't been changed), after the lock has
         # been changed and the former lock is released, the waiting thread will acquire
@@ -222,7 +232,7 @@ def lock_tty(func: FunctionType) -> FunctionType:
 
 
 @no_redecorate
-def terminal_size_cached(func: FunctionType) -> FunctionType:
+def terminal_size_cached(func: Callable[P, T]) -> Callable[P, T]:
     """Enables return value caching based on the size of the :term:`active terminal`.
 
     Args:
@@ -240,28 +250,33 @@ def terminal_size_cached(func: FunctionType) -> FunctionType:
         It's thread-safe, i.e there is no race condition between calls to the same
         decorated callable across threads of the same process.
     """
+    cache: tuple[T, os.terminal_size] | None = None
+    lock = RLock()
 
     @wraps(func)
-    def terminal_size_cached_wrapper(*args, **kwargs):
+    def terminal_size_cached_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        nonlocal cache
+
         with lock:
             ts = get_terminal_size()
             if not cache or ts != cache[1]:
-                cache[:] = [func(*args, **kwargs), ts]
+                cache = (func(*args, **kwargs), ts)
+
         return cache[0]
 
-    def invalidate():
-        with lock:
-            cache.clear()
+    def invalidate() -> None:
+        nonlocal cache
 
-    cache = []
-    lock = RLock()
-    terminal_size_cached_wrapper._invalidate_terminal_size_cache = invalidate
+        with lock:
+            cache = None
+
+    setattr(terminal_size_cached_wrapper, "_invalidate_terminal_size_cache", invalidate)
 
     return terminal_size_cached_wrapper
 
 
 @no_redecorate
-def unix_tty_only(func: FunctionType) -> FunctionType:
+def unix_tty_only(func: Callable[P, T]) -> Callable[P, T | None]:
     """Disable invocation of a function on a non-unix-like platform or when there is no
     :term:`active terminal`.
 
@@ -270,8 +285,11 @@ def unix_tty_only(func: FunctionType) -> FunctionType:
     """
 
     @wraps(func)
-    def unix_only_wrapper(*args, **kwargs):
-        return _tty_fd and func(*args, **kwargs)
+    def unix_only_wrapper(*args: P.args, **kwargs: P.kwargs) -> T | None:
+        return None if _tty_fd == -1 else func(*args, **kwargs)
+
+    if unix_only_wrapper.__doc__ is None:
+        unix_only_wrapper.__doc__ = ""
 
     unix_only_wrapper.__doc__ += """
     NOTE:
@@ -325,7 +343,7 @@ def arg_value_error_range(arg: str, value: Any, got_extra: str = "") -> ValueErr
     )
 
 
-def clear_queue(queue: Union[Queue, mp_Queue]):
+def clear_queue(queue: Queue[Any] | mp_Queue[Any]) -> None:
     """Purges the given queue"""
     while True:
         try:
@@ -472,7 +490,7 @@ def get_fg_bg_colors(
 
 
 @cached
-def get_terminal_name_version() -> Tuple[Optional[str], Optional[str]]:
+def get_terminal_name_version() -> tuple[str | None, str | None]:
     """Returns the name and version of the :term:`active terminal`, if available.
 
     Returns:
@@ -517,14 +535,13 @@ def get_terminal_size() -> os.terminal_size:
         - gives different results in certain situations
         - is what this library works with
     """
-    if _tty_fd:
+    size = None
+    if _tty_fd != -1:
         # faster and gives correct results when output is redirected
         try:
             size = os.get_terminal_size(_tty_fd)
         except OSError:
-            size = None
-    else:
-        size = None
+            pass
 
     return size or _get_terminal_size()
 
@@ -532,8 +549,8 @@ def get_terminal_size() -> os.terminal_size:
 @unix_tty_only
 @lock_tty
 def query_terminal(
-    request: bytes, more: Callable[[bytearray], bool], timeout: float = None
-) -> Optional[bytes]:
+    request: bytes, more: Callable[[bytearray], bool], timeout: float | None = None
+) -> bytes | None:
     """Sends a query to the :term:`active terminal` and returns the response.
 
     Args:
@@ -577,11 +594,11 @@ def query_terminal(
 @lock_tty
 def read_tty(
     more: Callable[[bytearray], bool] = lambda _: True,
-    timeout: Optional[float] = None,
+    timeout: float | None = None,
     min: int = 0,
     *,
     echo: bool = False,
-) -> bytes:
+) -> bytes | None:
     """Reads input directly from the :term:`active terminal` with/without blocking.
 
     Args:
@@ -598,7 +615,7 @@ def read_tty(
 
     Returns:
         The input read (empty, if *min* == ``0`` (default) and no input is received
-        before *timeout* is up).
+        before *timeout* is up) or ``None`` if not supported.
 
     If *timeout* is ``None`` (default), all available input is read without blocking.
 
@@ -630,8 +647,10 @@ def read_tty(
 
     input = bytearray()
     try:
-        termios.tcsetattr(_tty_fd, termios.TCSANOW, new_attr)
+        w: list[int]
+        x: list[int]
         r, w, x = [_tty_fd], [], []
+        termios.tcsetattr(_tty_fd, termios.TCSANOW, new_attr)
 
         if timeout is None:
             # VMIN=0 does not work as expected on some platforms when there's no input
@@ -661,12 +680,12 @@ def read_tty(
 
 
 @unix_tty_only
-def read_tty_all() -> bytes:
+def read_tty_all() -> bytes | None:
     """Reads all available input directly from the :term:`active terminal` **without
     blocking**.
 
     Returns:
-        The input read.
+        The input read or ``None`` if not supported.
 
     IMPORTANT:
         Synchronized with :py:func:`~term_image.utils.lock_tty`.
@@ -689,6 +708,7 @@ def write_tty(data: bytes) -> None:
         pass
 
 
+@no_type_check
 def _process_start_wrapper(self, *args, **kwargs):
     global _tty_lock, _cell_size_cache, _cell_size_lock
 
@@ -733,6 +753,7 @@ def _process_start_wrapper(self, *args, **kwargs):
     return _process_start_wrapper.__wrapped__(self, *args, **kwargs)
 
 
+@no_type_check
 def _process_run_wrapper(self, *args, **kwargs):
     global _tty_lock, _cell_size_cache, _cell_size_lock
 
@@ -747,9 +768,9 @@ def _process_run_wrapper(self, *args, **kwargs):
 
 # Private internal variables
 _query_timeout = 0.1
-_queries_enabled: bool = True
-_swap_win_size: bool = False
-_tty_fd: Optional[int] = None
+_queries_enabled = True
+_swap_win_size = False
+_tty_fd = -1
 _tty_lock = RLock()
 _cell_size_cache = [0] * 4
 _cell_size_lock = RLock()
@@ -758,7 +779,11 @@ _rlock_type = type(_tty_lock)
 if OS_IS_UNIX:
     for stream in ("out", "in", "err"):  # In order of priority
         try:
-            _tty_fd = os.ttyname(getattr(sys, f"__std{stream}__").fileno())
+            # A new file descriptor is required because, at least, both read and write
+            # access to the T/PTY are required.
+            _tty_fd = os.open(
+                os.ttyname(getattr(sys, f"__std{stream}__").fileno()), os.O_RDWR
+            )
             break
         except (OSError, AttributeError):
             pass
@@ -776,12 +801,14 @@ if OS_IS_UNIX:
                 "`TermImageWarning` won't be available).",
                 TermImageWarning,
             )
-    if _tty_fd:
-        if isinstance(_tty_fd, str):
-            _tty_fd = os.open(_tty_fd, os.O_RDWR)
 
-        Process.start = wraps(Process.start)(_process_start_wrapper)
-        Process.run = wraps(Process.run)(_process_run_wrapper)
+    if _tty_fd != -1:
+        Process.start = wraps(Process.start)(  # type: ignore[method-assign]
+            _process_start_wrapper
+        )
+        Process.run = wraps(Process.run)(  # type: ignore[method-assign]
+            _process_run_wrapper
+        )
 
         # Shouldn't be needed since we're getting our own separate file descriptors
         # but the validity of the assumed safety is still under probation

--- a/tests/render/test_iterator.py
+++ b/tests/render/test_iterator.py
@@ -133,23 +133,6 @@ def get_loop_frames(renderable, cache=Ellipsis):
 # # Constructor ==================================================================
 
 
-def test_args():
-    with pytest.raises(TypeError, match="'renderable'"):
-        RenderIterator(Ellipsis)
-
-    with pytest.raises(TypeError, match="'render_args'"):
-        RenderIterator(anim_space, Ellipsis)
-
-    with pytest.raises(TypeError, match="'padding'"):
-        RenderIterator(anim_space, padding=Ellipsis)
-
-    with pytest.raises(TypeError, match="'loops'"):
-        RenderIterator(anim_space, loops=Ellipsis)
-
-    with pytest.raises(TypeError, match="'cache'"):
-        RenderIterator(anim_space, cache=Ellipsis)
-
-
 class TestRenderable:
     def test_non_animated(self):
         with pytest.raises(ValueError, match="not animated"):
@@ -499,11 +482,6 @@ def test_close():
 
 
 class TestSeek:
-    def test_args(self):
-        render_iter = RenderIterator(anim_space)
-        with pytest.raises(TypeError, match="offset"):
-            render_iter.seek(Ellipsis)
-
     class TestDefinite:
         anim_space_seeked = Space(2, 1)
         anim_space_seeked.seek(1)
@@ -749,7 +727,7 @@ class TestSetFrameDuration:
     anim_space = Space(5, 1)
 
     @pytest.mark.parametrize("duration", [0, -1])
-    def test_arg_duration(self, duration):
+    def test_args(self, duration):
         render_iter = RenderIterator(self.anim_space)
         with pytest.raises(ValueError, match="duration"):
             render_iter.set_frame_duration(duration)
@@ -814,11 +792,6 @@ class TestSetFrameDuration:
 class TestSetPadding:
     anim_char = Char(5, 1)
     render_args = +Char.Args(char="#")
-
-    def test_args(self):
-        render_iter = RenderIterator(self.anim_char, self.render_args)
-        with pytest.raises(TypeError, match="padding"):
-            render_iter.set_padding(Ellipsis)
 
     def test_iteration(self):
         render_iter = RenderIterator(self.anim_char, self.render_args)
@@ -896,10 +869,8 @@ class TestSetPadding:
 class TestSetRenderArgs:
     anim_char = Char(5, 1)
 
-    def test_args(self):
+    def test_incompatible(self):
         render_iter = RenderIterator(self.anim_char)
-        with pytest.raises(TypeError, match="render_args"):
-            render_iter.set_render_args(Ellipsis)
         with pytest.raises(IncompatibleRenderArgsError):
             render_iter.set_render_args(RenderArgs(Space))
 
@@ -962,11 +933,6 @@ class TestSetRenderArgs:
 
 class TestSetRenderSize:
     anim_space = Space(5, 1)
-
-    def test_args(self):
-        render_iter = RenderIterator(self.anim_space)
-        with pytest.raises(TypeError, match="render_size"):
-            render_iter.set_render_size(Ellipsis)
 
     def test_iteration(self):
         render_iter = RenderIterator(self.anim_space)
@@ -1031,13 +997,9 @@ class TestFromRenderData:
         finalized_render_data = anim_space._get_render_data_(iteration=True)
         finalized_render_data.finalize()
 
-        with pytest.raises(TypeError, match="'renderable'"):
-            RenderIterator._from_render_data_(Ellipsis, render_data)
         with pytest.raises(ValueError, match="not animated"):
             RenderIterator._from_render_data_(space, render_data)
 
-        with pytest.raises(TypeError, match="'render_data'"):
-            RenderIterator._from_render_data_(anim_space, Ellipsis)
         with pytest.raises(ValueError, match="'Space'"):
             RenderIterator._from_render_data_(
                 anim_space, anim_char._get_render_data_(iteration=True)
@@ -1049,21 +1011,9 @@ class TestFromRenderData:
         with pytest.raises(ValueError, match="finalized"):
             RenderIterator._from_render_data_(anim_space, finalized_render_data)
 
-        with pytest.raises(TypeError, match="'render_args'"):
-            RenderIterator._from_render_data_(
-                anim_space, render_data, render_args=Ellipsis
-            )
         with pytest.raises(IncompatibleRenderArgsError):
             RenderIterator._from_render_data_(
                 anim_space, render_data, render_args=RenderArgs(FrameFill)
-            )
-
-        with pytest.raises(TypeError, match="'padding'"):
-            RenderIterator._from_render_data_(anim_space, render_data, padding=Ellipsis)
-
-        with pytest.raises(TypeError, match="'finalize'"):
-            RenderIterator._from_render_data_(
-                anim_space, render_data, finalize=Ellipsis
             )
 
     def test_render_data(self):

--- a/tests/renderable/test_renderable.py
+++ b/tests/renderable/test_renderable.py
@@ -13,7 +13,6 @@ import pytest
 from term_image.ctlseqs import HIDE_CURSOR, SHOW_CURSOR
 from term_image.geometry import Size
 from term_image.padding import AlignedPadding, ExactPadding, HAlign, VAlign
-from term_image.render import RenderIterator
 from term_image.renderable import (
     ArgsNamespace,
     DataNamespace,
@@ -26,7 +25,6 @@ from term_image.renderable import (
     Renderable,
     RenderableError,
     RenderArgs,
-    RenderData,
     RenderSizeOutofRangeError,
     Seek,
     UninitializedDataFieldError,
@@ -692,7 +690,6 @@ class TestIter:
     def test_animated(self):
         anim_char = Char(2, 1)
         render_iter = iter(anim_char)
-        assert isinstance(render_iter, RenderIterator)
         assert render_iter.loop == 1  # loop count
 
         frame = next(render_iter)
@@ -1618,22 +1615,14 @@ class TestInitRender:
 
         @pytest.mark.parametrize("renderable", [space, char])
         def test_arguments(self, renderable):
-            renderer_args = renderable._init_render_(lambda *args: args)[0]
-            assert isinstance(renderer_args, tuple)
-            assert len(renderer_args) == 2
-
-            render_data, render_args = renderer_args
-            assert isinstance(render_data, RenderData)
+            render_data, render_args = renderable._init_render_(lambda *args: args)[0]
             assert render_data.render_cls is type(renderable)
-            assert isinstance(render_args, RenderArgs)
             assert render_args.render_cls is type(renderable)
 
         # See also: `TestInitRender.TestIteration`
         @pytest.mark.parametrize("data", [None, Ellipsis, " ", []])
         def test_render_data(self, data):
             render_data = self.Foo(data)._init_render_(lambda *args: args)[0][0]
-
-            assert isinstance(render_data, RenderData)
             assert render_data.render_cls is self.Foo
             assert render_data[self.Foo].foo is data
 

--- a/tests/renderable/test_types.py
+++ b/tests/renderable/test_types.py
@@ -180,12 +180,12 @@ class TestNamespaceMeta:
             class Namespace(NamespaceBase):
                 pass
 
-            assert Namespace._RENDER_CLS is None
+            assert Namespace._associated is False
 
             class Namespace(NamespaceBase, render_cls=None):
                 pass
 
-            assert Namespace._RENDER_CLS is None
+            assert Namespace._associated is False
 
         def test_with_fields(self):
             with pytest.raises(RenderArgsDataError, match="Unassociated.* with fields"):

--- a/tests/renderable/test_types.py
+++ b/tests/renderable/test_types.py
@@ -343,19 +343,6 @@ class TestNamespace:
 
 
 class TestRenderArgs:
-    def test_args(self):
-        with pytest.raises(TypeError, match="'render_cls'"):
-            RenderArgs(Ellipsis)
-
-        with pytest.raises(TypeError, match="second argument"):
-            RenderArgs(Renderable, Ellipsis)
-
-        with pytest.raises(TypeError, match=r"'namespaces\[0\]'"):
-            RenderArgs(Renderable, RenderArgs(Renderable), Ellipsis)
-
-        with pytest.raises(TypeError, match=r"'namespaces\[1\]'"):
-            RenderArgs(Foo, Foo.Args(), Ellipsis)
-
     def test_base(self):
         render_args = RenderArgs(Renderable)
         assert render_args.render_cls is Renderable
@@ -615,11 +602,13 @@ class TestRenderArgs:
 
         render_args = RenderArgs(Bar)
 
-        with pytest.raises(TypeError, match="'render_cls'"):
-            render_args[Ellipsis]
-
+        # Unhashable
         with pytest.raises(TypeError, match="'render_cls'"):
             render_args[[]]
+
+        # Hashable but not a render class
+        with pytest.raises(TypeError, match="'render_cls'"):
+            render_args[Ellipsis]
 
         with pytest.raises(NoArgsNamespaceError):
             render_args[Bar]
@@ -692,11 +681,6 @@ class TestRenderArgs:
 
         args = (A.Args("1"), B.Args("2"), C.Args("3"), D.Args("4"))
 
-        def test_args(self):
-            render_args = RenderArgs(Foo)
-            with pytest.raises(TypeError, match="'render_cls'"):
-                render_args.convert(Ellipsis)
-
         def test_same_render_cls(self):
             render_args = RenderArgs(Foo, Foo.Args("bar", "foo"))
             assert render_args.convert(Foo) is render_args
@@ -735,9 +719,6 @@ class TestRenderArgs:
 
             render_args = RenderArgs(Foo)
 
-            with pytest.raises(TypeError, match="first argument"):
-                render_args.update(Ellipsis)
-
             with pytest.raises(TypeError, match="positional argument"):
                 render_args.update(Foo, Ellipsis)
 
@@ -745,9 +726,6 @@ class TestRenderArgs:
                 render_args.update(Foo.Args(), foo=Ellipsis)
 
             # propagated
-
-            with pytest.raises(TypeError, match=r"'namespaces\[1\]'"):
-                render_args.update(Foo.Args(), Ellipsis)
 
             with pytest.raises(ValueError, match="not a subclass"):
                 render_args.update(Bar)
@@ -851,11 +829,11 @@ class TestRenderArgs:
                     pass
 
                 render_args = SubRenderArgs(Renderable)
-                assert isinstance(render_args, SubRenderArgs)
+                assert type(render_args) is SubRenderArgs
                 assert render_args is SubRenderArgs(Renderable)
 
                 render_args = SubRenderArgs(Foo)
-                assert isinstance(render_args, SubRenderArgs)
+                assert type(render_args) is SubRenderArgs
                 assert render_args is SubRenderArgs(Foo)
 
         class TestInitRenderArgsWithSameRenderClsAndWithoutNamespaces:
@@ -1505,11 +1483,13 @@ class TestRenderData:
 
         render_data = RenderData(Bar)
 
-        with pytest.raises(TypeError, match="'render_cls'"):
-            render_data[Ellipsis]
-
+        # Unhashable
         with pytest.raises(TypeError, match="'render_cls'"):
             render_data[[]]
+
+        # Hashable but not a render class
+        with pytest.raises(TypeError, match="'render_cls'"):
+            render_data[Ellipsis]
 
         with pytest.raises(NoDataNamespaceError):
             render_data[Bar]

--- a/tests/test_top_level.py
+++ b/tests/test_top_level.py
@@ -1,61 +1,61 @@
 from operator import truediv
-from random import randint, random
 
 import pytest
 
 from term_image import AutoCellRatio, get_cell_ratio, set_cell_ratio
 from term_image.exceptions import TermImageError
+from term_image.geometry import Size
 
 from . import reset_cell_size_ratio, set_cell_size
 
 
 class TestCellRatio:
-    @reset_cell_size_ratio()
-    def test_args(self):
-        for value in (0, "1", ()):
-            with pytest.raises(TypeError):
-                set_cell_ratio(value)
-        for value in (0.0, -0.1, -1.0):
+    class TestManual:
+        @pytest.mark.parametrize("ratio", [0.0, -0.1, -1.0])
+        @reset_cell_size_ratio()
+        def test_invalid(self, ratio):
             with pytest.raises(ValueError):
-                set_cell_ratio(value)
+                set_cell_ratio(ratio)
 
-        set_cell_size(None)
-        for value in AutoCellRatio:
+        @pytest.mark.parametrize("ratio", [0.01, 0.5, 0.99, 1.0, 2.0])
+        @reset_cell_size_ratio()
+        def test_valid(self, ratio):
+            set_cell_ratio(ratio)
+            assert get_cell_ratio() == ratio
+
+    class TestAuto:
+        @pytest.mark.parametrize("auto_mode", AutoCellRatio)
+        @reset_cell_size_ratio()
+        def test_unsupported(self, auto_mode):
+            set_cell_size(None)
             with pytest.raises(TermImageError):
-                set_cell_ratio(value)
+                set_cell_ratio(auto_mode)
 
-    @reset_cell_size_ratio()
-    def test_fixed(self):
-        for value in (0.01, 0.1, 0.9, 0.99, 1.0, 2.0):
-            set_cell_ratio(value)
-            assert get_cell_ratio() == value
-
-        for _ in range(20):
-            value = random()
-            set_cell_ratio(value)
-            assert get_cell_ratio() == value
-
-    @reset_cell_size_ratio()
-    def test_fixed_auto(self):
-        set_cell_size((4, 9))
-        set_cell_ratio(AutoCellRatio.FIXED)
-        assert get_cell_ratio() == 4 / 9 == get_cell_ratio()
-
-        for _ in range(20):
-            cell_size = (randint(1, 20), randint(1, 20))
+        @pytest.mark.parametrize("cell_size", [Size(4, 9), Size(11, 20)])
+        @reset_cell_size_ratio()
+        def test_fixed(self, cell_size):
             set_cell_size(cell_size)
             set_cell_ratio(AutoCellRatio.FIXED)
-            assert get_cell_ratio() == truediv(*cell_size) == get_cell_ratio()
-            set_cell_size((0, 1))
             assert get_cell_ratio() == truediv(*cell_size)
 
-    @reset_cell_size_ratio()
-    def test_dynamic_auto(self):
-        set_cell_size((4, 9))
-        set_cell_ratio(AutoCellRatio.DYNAMIC)
-        assert get_cell_ratio() == 4 / 9 == get_cell_ratio()
+            # Same after cell size changes
+            set_cell_size(Size(1, 1))
+            assert get_cell_ratio() == truediv(*cell_size)
 
-        for _ in range(20):
-            cell_size = (randint(1, 20), randint(1, 20))
-            set_cell_size(cell_size)
-            assert get_cell_ratio() == truediv(*cell_size) == get_cell_ratio()
+        @reset_cell_size_ratio()
+        def test_dynamic(self):
+            set_cell_size(Size(4, 9))
+            set_cell_ratio(AutoCellRatio.DYNAMIC)
+            assert get_cell_ratio() == 4 / 9 == get_cell_ratio()
+
+            # Changes along with cell size
+            set_cell_size(Size(11, 20))
+            assert get_cell_ratio() == 11 / 20 == get_cell_ratio()
+
+            # Use 0.5 when cell size can't be determined
+            set_cell_size(None)
+            assert get_cell_ratio() == 1 / 2 == get_cell_ratio()
+
+            # Back to normal when cell size can be determined
+            set_cell_size(Size(5, 5))
+            assert get_cell_ratio() == 5 / 5 == get_cell_ratio()


### PR DESCRIPTION
- Incorporates static typing & type checking.
- Adds, updates, corrects and removes type hints across the library.
  - With the exception of the `image` and `widget` sub-packages as those should go through massive changes real soon, which should come along with static typing.
- Modifies some interfaces for better static typing.
- Eliminates runtime argument type validation.
- Adds `typing_extensions` dependency.
- Adds `mypy` dev dependency.
- Adds a GitHub workflow for static type checking with `mypy`.

 - - -

## Background

I've always been quite on the opposing side concerning this - thus far, annotations have only for documentation purposes - but I've come to realize the potential benefits of proper static type checking, both to the project itself and to its users.

That said, I'm still quite reserved about this as I've also realized this area is quite a slippery slope. It's just a thin line between adequate type hinting for type checking and spending valuable time writing unreadable or non-concise code just to satisfy a static type checker... and I'm not and will never be willing to cross that line (at least, not within this project).

One must understand and always keep in mind that Python is not a statically-typed language and really wasn't designed from the ground to be used that way but I'm willing to employ static typing to the extent that it doesn't result in poorer design, implementation or performance than dynamic typing.

Personally, I tend to play to the strengths of whatever language I use, which in the case of Python (IMHO) is majorly the fact that it's highly dynamic (in most cases) and fosters design and implementation of that kind. I tend to use quite a lot of these aspects of Python where reasonably applicable but will now try to find compromises where and when feasible.