### PR TITLE
Redesign Render Arguments & Data Namespace APIs

### DIFF
--- a/docs/source/api/renderable.rst
+++ b/docs/source/api/renderable.rst
@@ -239,10 +239,10 @@ ArgsNamespace
 
    .. attention::
 
-      Due to the design of the API, if a render class is intended to have a namespace
-      class asssociated, the namespace class should be associated with it before it
-      is subclassed or any :py:class:`~term_image.renderable.RenderArgs` instance
-      associated with it is created.
+      Due to the design of the Renderable API, if a render class is intended to have
+      a namespace class asssociated, the namespace class should be associated with it
+      before it is subclassed or any :py:class:`~term_image.renderable.RenderArgs`
+      instance associated with it is created.
 
 
    .. _inheriting-fields:

--- a/docs/source/api/renderable.rst
+++ b/docs/source/api/renderable.rst
@@ -8,19 +8,25 @@ Classes
 
 .. automodulesumm:: term_image.renderable
    :autosummary-no-titles:
-   :autosummary-members: Renderable, RenderArgs, Frame
+   :autosummary-members: Renderable, RenderArgs, ArgsNamespace, Frame
 
 
 .. autoclass:: Renderable
+   :no-autosummary:
    :special-members: __iter__, __str__
+   :exclude-members: Args
+
+   .. autoclasssumm:: Renderable
+      :autosummary-special-members: __iter__, __str__
+
+   .. autoattribute:: Args()
+      :no-value:
 
 |
 
 .. autoclass:: RenderArgs
-   :autosummary-exclude-members:
    :special-members: __eq__, __getitem__, __hash__, __iter__
    :inherited-members: render_cls
-   :exclude-members: Namespace
 
    .. rubric:: Footnotes
 
@@ -33,7 +39,7 @@ Classes
 
 |
 
-.. autoclass:: term_image.renderable.RenderArgs.Namespace
+.. autoclass:: ArgsNamespace
    :special-members: __eq__, __hash__, __or__, __pos__, __ror__
    :inherited-members: get_render_cls
 
@@ -42,11 +48,10 @@ Classes
    .. rubric:: Footnotes
 
    .. [#ran1]
-      A render argument namespace class, its subclasses and their instances are
-      associated with the :term:`render class` that defines (not inherits) the namespace
-      class as its :ref:`Args <renderable-args>` attribute **at its creation**.
-      The associated render class is accessible via
-      :py:meth:`~term_image.renderable.RenderArgs.Namespace.get_render_cls`.
+      A render argument namespace class (**that has fields**), along with its
+      subclasses and their instances, is associated with the :term:`render class`
+      that was :ref:`specified <associating-namespace>` **at its creation**.
+      The associated render class is accessible via :py:meth:`get_render_cls`.
    .. [#ran2]
       A render argument namespace is compatible with its associated [#ran1]_
       :term:`render class` and the subclasses thereof.
@@ -138,6 +143,7 @@ Renderable
 
    .. autoclasssumm:: Renderable
       :autosummary-members:
+        _Data_,
         _EXPORTED_ATTRS_,
         _EXPORTED_DESCENDANT_ATTRS_,
         _animate_,
@@ -148,8 +154,9 @@ Renderable
         _handle_interrupted_draw_,
         _init_render_,
         _render_,
-        _Data_,
 
+   .. autoattribute:: _Data_()
+      :no-value:
    .. autoattribute:: _EXPORTED_ATTRS_
    .. autoattribute:: _EXPORTED_DESCENDANT_ATTRS_
    .. automethod:: _animate_
@@ -162,179 +169,21 @@ Renderable
    .. automethod:: _init_render_
    .. automethod:: _render_
 
-.. autoclass:: term_image.renderable.Renderable._Data_
-
-|
-
-.. _renderable-args:
-
-Renderable.Args
-"""""""""""""""
-.. py:attribute:: Renderable.Args
-   :noindex:
-   :type: typing.ClassVar[type[RenderArgs.Namespace] | None]
-
-   :term:`Render class`\ -specific render arguments.
-
-   If this is a class, it must be a subclass of :py:class:`RenderArgs.Namespace` that
-   **has fields** and **has NOT been associated** with a render class. It defines the
-   render arguments of the render class defining this attribute.
-
-   An instance of this class (``Args``), is contained in any :py:class:`RenderArgs`
-   instance associated [#ra2]_ with the render class defining this attribute or any
-   of its subclasses.
-
-   Also, an instance of this class (``Args``) is returned by
-   :py:meth:`render_args[render_cls] <RenderArgs.__getitem__>`, where *render_args* is
-   an instance of :py:class:`~term_image.renderable.RenderArgs` as previously described
-   and *render_cls* is the render class defining this attribute.
-
-   .. collapse:: Example
-
-      >>> class Foo(Renderable):
-      ...     class Args(RenderArgs.Namespace):
-      ...         foo: str | None = None
-      ...
-      >>> # default
-      >>> Foo.Args()
-      Foo.Args(foo=None)
-      >>> render_args = RenderArgs(Foo)
-      >>> render_args[Foo]
-      Foo.Args(foo=None)
-      >>>
-      >>> # non-default
-      >>> foo_args = Foo.Args("FOO")
-      >>> foo_args
-      Foo.Args(foo='FOO')
-      >>> render_args = RenderArgs(Foo, foo_args.update(foo="bar"))
-      >>> render_args[Foo]
-      Foo.Args(foo='bar')
-
-   On the other hand, if this is ``None``, it implies the render class defines no
-   render arguments.
-
-   .. collapse:: Example
-
-      >>> class Bar(Renderable):
-      ...     pass
-      ...
-      >>> assert Bar.Args is None
-      >>> render_args = RenderArgs(Bar)
-      >>> render_args[Bar]
-      Traceback (most recent call last):
-        ...
-      NoArgsNamespaceError: 'Bar' defines no render arguments
-
-   .. note::
-
-      * If this attribute is not defined at creation of a render class, it's set to
-        ``None``.
-      * If this attribute is intended to be a class, it must be defined before the
-        creation of the render class.
-      * Modifying this attribute after creation of the render class neither associates
-        nor disassociates a render argument namespace class.
-
-|
-
-.. _renderable-data:
-
-Renderable._Data_
-"""""""""""""""""
-.. py:attribute:: Renderable._Data_
-   :noindex:
-   :type: typing.ClassVar[type[RenderData.Namespace] | None]
-
-   :term:`Render class`\ -specific render data.
-
-   If this is a class, it must be a subclass of :py:class:`RenderData.Namespace` that
-   **has fields** and **has NOT been associated** with a render class. It defines the
-   render data of the render class defining this attribute.
-
-   An instance of this class (``_Data_``), is contained in any :py:class:`RenderData`
-   instance associated [#rd1]_ with the render class defining this attribute or any
-   of its subclasses.
-
-   Also, an instance of this class (``_Data_``) is returned by
-   :py:meth:`render_data[render_cls] <RenderData.__getitem__>`, where *render_data* is
-   an instance of :py:class:`~term_image.renderable.RenderData` as previously described
-   and *render_cls* is the render class defining this attribute.
-
-   .. collapse:: Example
-
-      >>> class Foo(Renderable):
-      ...     class _Data_(RenderData.Namespace):
-      ...         foo: str | None
-      ...
-      >>> foo_data = Foo._Data_()
-      >>> foo_data
-      <Foo._Data_: foo=<uninitialized>>
-      >>> foo_data.foo
-      Traceback (most recent call last):
-        ...
-      UninitializedDataFieldError: The render data field 'foo' of 'Foo' has not been initialized
-      >>>
-      >>> foo_data.foo = "FOO"
-      >>> foo_data
-      <Foo._Data_: foo='FOO'>
-      >>> assert foo_data.foo == "FOO"
-      >>>
-      >>> render_data = RenderData(Foo)
-      >>> render_data[Foo]
-      <Foo._Data_: foo=<uninitialized>>
-      >>>
-      >>> render_data[Foo].foo = "bar"
-      >>> render_data[Foo]
-      <Foo._Data_: foo='bar'>
-
-   On the other hand, if this is ``None``, it implies the render class defines no
-   render data.
-
-   .. collapse:: Example
-
-      >>> class Bar(Renderable):
-      ...     pass
-      ...
-      >>> assert Bar._Data_ is None
-      >>>
-      >>> render_data = RenderData(Bar)
-      >>> render_data[Bar]
-      Traceback (most recent call last):
-        ...
-      NoDataNamespaceError: 'Bar' defines no render data
-
-   .. note::
-
-      * If this attribute is not defined at creation of a render class, it's set to
-        ``None``.
-      * If this attribute is intended to be a class, it must be defined before the
-        creation of the render class.
-      * Modifying this attribute after creation of the render class neither associates
-        nor disassociates a render data namespace class.
-
-   .. seealso:: :py:class:`Renderable._Data_ <term_image.renderable.Renderable._Data_>`.
-
 |
 
 .. _args-namespace:
 
-RenderArgs.Namespace
+ArgsNamespace
 ^^^^^^^^^^^^^^^^^^^^
 
-.. py:class:: RenderArgs.Namespace
+.. py:class:: ArgsNamespace
    :noindex:
 
-   See :py:class:`RenderArgs.Namespace <term_image.renderable.RenderArgs.Namespace>`
-   for the public API.
+   See :py:class:`~term_image.renderable.ArgsNamespace` for the public API.
 
-   .. rubric:: Subclassing
 
-   * A subclass cannot have multiple base classes.
-   * A subclass that **has fields** cannot be further subclassed until it is
-     associated with a render class.
-   * Every subclass, of a subclass that **has fields**, must not define fields.
-   * A subclass' constructor must not have required parameters.
-
-   .. rubric:: Defining Fields
+   Defining Fields
+   """""""""""""""
 
    Fields are defined as **annotated** class attributes. All annotated attributes of a
    subclass are taken to be fields. Every such attribute must be assigned a value which
@@ -342,49 +191,106 @@ RenderArgs.Namespace
 
    .. collapse:: Example
 
-      >>> class Args(RenderArgs.Namespace):
+      >>> class Foo(Renderable):
+      ...     pass
+      ...
+      >>> class FooArgs(ArgsNamespace, render_cls=Foo):
       ...     foo: str = "FOO"
       ...     bar: str = "BAR"
       ...
-      >>> Args.get_fields()
+      >>> FooArgs.get_fields()
       mappingproxy({'foo': 'FOO', 'bar': 'BAR'})
 
    The attribute annotations are only used to identify the fields, they're never
    evaluated or used otherwise by any part of the Renderable API.
    The field names will be unbound from their assigned values (the default field
-   values) during the creation of the subclass.
+   values) during the creation of the class.
 
-   .. rubric:: Inheriting Fields
+   .. note::
 
-   Fields may be inherited from any associated render argument namespace class
-   (i.e any subclass of this class that has been associated with a render class) by
-   subclassing it. The new subclass inherits the fields and associated render class of
-   its parent.
+      A subclass that :ref:`inherits <inheriting-fields>` fields must not define fields.
+
+
+   .. _associating-namespace:
+
+   Associating With a Render Class
+   """""""""""""""""""""""""""""""
+
+   To associate a namespace class with a render class, the render class should be
+   specified via the *render_cls* keyword argument in the class definition header.
 
    .. collapse:: Example
 
-      >>> class Args1(RenderArgs.Namespace):
-      ...     foo: str = "FOO"
-      ...
-      >>> Args1.get_fields()
-      mappingproxy({'foo': 'FOO'})
-      >>>
       >>> class Foo(Renderable):
-      ...     Args = Args1
-      ...
-      >>> assert Args1.get_render_cls() is Foo
-      >>>
-      >>> class Args2(Args1):
       ...     pass
       ...
-      >>> assert Args2.get_render_cls() is Foo
-      >>> Args2.get_fields()
+      >>> class FooArgs(ArgsNamespace, render_cls=Foo):
+      ...     foo: str = "FOO"
+      ...
+      >>> FooArgs.get_render_cls() is Foo
+      True
+
+   .. note::
+
+      * A subclass that **has fields** must be associated [#ran1]_ with a render class.
+      * A subclass that **has NO fields** cannot be associated with a render class.
+      * A subclass that :ref:`inherits <inheriting-fields>` fields cannot be
+        reassociated with another render class.
+
+   .. attention::
+
+      Due to the design of the API, if a render class is intended to have a namespace
+      class asssociated, the namespace class should be associated with it before it
+      is subclassed or any :py:class:`~term_image.renderable.RenderArgs` instance
+      associated with it is created.
+
+
+   .. _inheriting-fields:
+
+   Inheriting Fields
+   """""""""""""""""
+
+   Fields are inherited from any associated [#ran1]_ render argument namespace class
+   (i.e anyone that **has fields**) by subclassing it. The new subclass inherits both
+   the fields and associated render class of its parent.
+
+   .. collapse:: Example
+
+      >>> class Foo(Renderable):
+      ...     pass
+      ...
+      >>> class FooArgs(ArgsNamespace, render_cls=Foo):
+      ...     foo: str = "FOO"
+      ...
+      >>> FooArgs.get_render_cls() is Foo
+      True
+      >>> FooArgs.get_fields()
+      mappingproxy({'foo': 'FOO'})
+      >>>
+      >>> class SubFooArgs(FooArgs):
+      ...     pass
+      ...
+      >>> SubFooArgs.get_render_cls() is Foo
+      True
+      >>> SubFooArgs.get_fields()
       mappingproxy({'foo': 'FOO'})
 
-   .. rubric:: Associating With a Render Class
+   .. note::
 
-   * A subclass that **has NO fields** cannot be associated with a render class.
-   * A subclass that **has fields** may be associated with **only one** render class.
+      A subclass that inherits fields:
+
+      * must not define fields.
+      * cannot be reassociated with another render class.
+
+
+   Other Notes
+   """""""""""
+
+   .. note::
+
+      * A subclass cannot have multiple base classes.
+      * The constructor of any subclass that **has fields** must not have required
+        parameters.
 
    .. tip::
 
@@ -406,25 +312,26 @@ RenderArgs.Namespace
           containing such a namespace) may be in use in an asynchronous render
           operation,
         * different sets of render arguments may contain the same namespace, and
-        * different namespaces may contain the same object as the field values.
+        * different namespaces may contain the same object as field values.
 
       * be **hashable**.
 
         Otherwise, the namespace and any containing set of render arguments will also
         not be hashable.
 
-   .. seealso:: :ref:`renderable-args`.
-
 |
 
-RenderData
-^^^^^^^^^^
+Other Classes
+^^^^^^^^^^^^^
+
+.. automodulesumm:: term_image.renderable
+   :autosummary-no-titles:
+   :autosummary-members: RenderData, DataNamespace, RenderableData
+
 
 .. autoclass:: RenderData
-   :autosummary-exclude-members:
    :special-members: __getitem__, __iter__
    :inherited-members: render_cls
-   :exclude-members: Namespace
 
    .. rubric:: Footnotes
 
@@ -434,14 +341,17 @@ RenderData
 
 |
 
-.. autoclass:: term_image.renderable.RenderData.Namespace
+.. autoclass:: DataNamespace
    :inherited-members: get_render_cls
 
    .. rubric:: Footnotes
 
    .. [#rdn1]
-      A render data namespace class, its subclasses and their instances are associated
-      with the :term:`render class` that defines (not inherits) the namespace class as
-      its :ref:`_Data_ <renderable-data>` attribute **at its creation**.
-      The associated render class is accessible via
-      :py:meth:`~term_image.renderable.RenderData.Namespace.get_render_cls`.
+      A render data namespace class (**that has fields**), along with its
+      subclasses and their instances, is associated with the :term:`render class`
+      that was :ref:`specified <associating-namespace>` **at its creation**.
+      The associated render class is accessible via :py:meth:`get_render_cls`.
+
+|
+
+.. autoclass:: RenderableData

--- a/src/term_image/renderable/__init__.py
+++ b/src/term_image/renderable/__init__.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 __all__ = (
     "Renderable",
     "RenderArgs",
+    "ArgsNamespace",
     "RenderData",
+    "DataNamespace",
+    "RenderableData",
     "Frame",
     "FrameCount",
     "FrameDuration",
@@ -38,8 +41,10 @@ from ._exceptions import (
     RenderError,
     RenderSizeOutofRangeError,
 )
-from ._renderable import Renderable
+from ._renderable import Renderable, RenderableData
 from ._types import (
+    ArgsNamespace,
+    DataNamespace,
     Frame,
     IncompatibleArgsNamespaceError,
     IncompatibleRenderArgsError,

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -185,7 +185,7 @@ class Renderable(metaclass=RenderableMeta, _base=True):
        >>> render_args[Bar]
        Traceback (most recent call last):
          ...
-       NoArgsNamespaceError: 'Bar' defines no render arguments
+       NoArgsNamespaceError: 'Bar' has no render arguments
     """
 
     # Initialized by `RenderableMeta` and may be updated by `DataNamespaceMeta`
@@ -256,7 +256,7 @@ been initialized
        >>> render_data[Bar]
        Traceback (most recent call last):
          ...
-       NoDataNamespaceError: 'Bar' defines no render data
+       NoDataNamespaceError: 'Bar' has no render data
 
     .. seealso::
 

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = ("Renderable",)
+__all__ = ("Renderable", "RenderableData")
 
 import sys
 from abc import ABCMeta, abstractmethod
@@ -26,7 +26,7 @@ from ._exceptions import (
     RenderableError,
     RenderSizeOutofRangeError,
 )
-from ._types import Frame, RenderArgs, RenderData
+from ._types import ArgsNamespace, DataNamespace, Frame, RenderArgs, RenderData
 
 try:
     import termios
@@ -46,67 +46,13 @@ class RenderableMeta(ABCMeta):
         if not _base and not any(issubclass(base, Renderable) for base in bases):
             raise RenderableError(f"{name!r} is not a subclass of 'Renderable'")
 
-        try:
-            args_cls = namespace["Args"]
-        except KeyError:
-            args_cls = None
-
-        if args_cls is not None:
-            if not isinstance(args_cls, type):
-                raise arg_type_error(f"'{name}.Args'", args_cls)
-            if not issubclass(args_cls, RenderArgs.Namespace):
-                raise RenderableError(
-                    f"'{name}.Args' is not a subclass of 'RenderArgs.Namespace'"
-                )
-            if not args_cls._FIELDS:
-                raise RenderableError(f"'{name}.Args' has no fields")
-            if args_cls._RENDER_CLS:
-                raise RenderableError(
-                    f"'{name}.Args' is already associated with render class "
-                    f"{args_cls._RENDER_CLS.__name__!r}"
-                )
-
-        try:
-            data_cls = namespace["_Data_"]
-        except KeyError:
-            data_cls = None
-
-        if data_cls is not None:
-            if not isinstance(data_cls, type):
-                raise arg_type_error(f"'{name}._Data_'", data_cls)
-            if not issubclass(data_cls, RenderData.Namespace):
-                raise RenderableError(
-                    f"'{name}._Data_' is not a subclass of 'RenderData.Namespace'"
-                )
-            if not data_cls._FIELDS:
-                raise RenderableError(f"'{name}._Data_' has no fields")
-            if data_cls._RENDER_CLS:
-                raise RenderableError(
-                    f"'{name}._Data_' is already associated with render class "
-                    f"{data_cls._RENDER_CLS.__name__!r}"
-                )
-
         new_cls = super().__new__(cls, name, bases, namespace, **kwargs)
 
-        if args_cls:
-            args_cls._RENDER_CLS = new_cls
-        else:
-            new_cls.Args = None
+        all_default_args = {}
+        render_data_mro = {}
+        all_exported_descendant_attrs = set()  # removes duplicates
 
-        if data_cls:
-            data_cls._RENDER_CLS = new_cls
-        else:
-            new_cls._Data_ = None
-
-        if _base:  # Renderable
-            all_default_args = {}
-            render_data_mro = {new_cls: new_cls._Data_}
-            all_exported_descendant_attrs = frozenset()
-        else:
-            all_default_args = {new_cls: args_cls()} if args_cls else {}
-            render_data_mro = {new_cls: data_cls} if data_cls else {}
-            all_exported_descendant_attrs = set()  # remove duplicates
-
+        if not _base:  # Subclass of `Renderable`
             for mro_cls in new_cls.__mro__:
                 if not issubclass(mro_cls, Renderable):
                     continue
@@ -115,7 +61,7 @@ class RenderableMeta(ABCMeta):
                     if mro_cls.Args:
                         all_default_args[mro_cls] = mro_cls._ALL_DEFAULT_ARGS[mro_cls]
                     if mro_cls._Data_:
-                        render_data_mro[mro_cls] = mro_cls._RENDER_DATA_MRO[mro_cls]
+                        render_data_mro[mro_cls] = mro_cls._Data_
                 try:
                     all_exported_descendant_attrs.update(
                         mro_cls.__dict__["_EXPORTED_DESCENDANT_ATTRS_"]
@@ -128,6 +74,7 @@ class RenderableMeta(ABCMeta):
         new_cls._ALL_EXPORTED_ATTRS = tuple(
             all_exported_descendant_attrs.union(namespace.get("_EXPORTED_ATTRS_", ()))
         )
+        new_cls.Args = new_cls._Data_ = None
 
         return new_cls
 
@@ -1008,7 +955,7 @@ class Renderable(metaclass=RenderableMeta, _base=True):
             The rendered frame.
 
             * *render_size* = :py:attr:`render_data[Renderable].size
-              <term_image.renderable.Renderable._Data_.size>`.
+              <term_image.renderable.RenderableData.size>`.
             * The :py:attr:`~term_image.renderable.Frame.render_output` field holds the
               :term:`render output`. This string should:
 
@@ -1033,11 +980,11 @@ class Renderable(metaclass=RenderableMeta, _base=True):
             * The value of the :py:attr:`~term_image.renderable.Frame.duration` field
               should be determined from the frame data source (or a default/fallback
               value, if undeterminable), if :py:attr:`render_data[Renderable].duration
-              <term_image.renderable.Renderable._Data_.duration>` is
+              <term_image.renderable.RenderableData.duration>` is
               :py:attr:`~term_image.renderable.FrameDuration.DYNAMIC`.
               Otherwise, it should be equal to
               :py:attr:`render_data[Renderable].duration
-              <term_image.renderable.Renderable._Data_.duration>`.
+              <term_image.renderable.RenderableData.duration>`.
 
         Raises:
             StopIteration: End of iteration for an animated renderable with
@@ -1047,135 +994,139 @@ class Renderable(metaclass=RenderableMeta, _base=True):
         NOTE:
             :py:class:`StopIteration` may be raised if and only if
             :py:attr:`render_data[Renderable].iteration
-            <term_image.renderable.Renderable._Data_.iteration>` is ``True``.
+            <term_image.renderable.RenderableData.iteration>` is ``True``.
             Otherwise, it would be out of place.
 
-        .. seealso:: :py:class:`~term_image.renderable.Renderable._Data_`.
+        .. seealso:: :py:class:`~term_image.renderable.RenderableData`.
         """
         raise NotImplementedError
 
-    # Inner classes ============================================================
 
-    class _Data_(RenderData.Namespace):
-        """_Data_()
-
-        Render data namespace for :py:class:`~term_image.renderable.Renderable`.
-
-        .. seealso::
-
-           :ref:`renderable-data`,
-           :py:meth:`~term_image.renderable.Renderable._render_`.
-        """
-
-        size: geometry.Size
-        """:term:`Render size`
-
-        See :py:meth:`~term_image.renderable.Renderable._render_`.
-        """
-
-        frame_offset: int
-        """Frame number/offset
-
-        If the :py:attr:`~term_image.renderable.Renderable.frame_count` of the
-        renderable (that generated the data) is:
-
-        * *definite* (i.e an integer); the value of this field is a **non-negative**
-          integer **less than the frame count**, the number of the frame to be rendered.
-        * :py:attr:`~term_image.renderable.FrameCount.INDEFINITE`, the value range and
-          interpretation of this field depends on the value of :py:attr:`iteration`
-          and :py:attr:`seek_whence`.
-
-          If :py:attr:`iteration` is ``False``, the value is always **zero** and
-          anything (such as a placeholder frame) may be rendered, as renderables with
-          :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` frame count are
-          typically meant for iteration/animation.
-
-          If :py:attr:`iteration` is ``True`` and :py:attr:`seek_whence` is:
-
-          * :py:attr:`~term_image.renderable.Seek.CURRENT`, the value of this field
-            may be:
-
-            * **zero**, denoting that the next frame on the stream should be rendered.
-            * **positive**, denoting that the stream should be seeked **forward** by
-              :py:attr:`frame_offset` frames and then the new next frame should be
-              rendered.
-            * **negative**, denoting that the stream should be seeked **backward** by
-              -:py:attr:`frame_offset` frames and then the new next frame should be
-              rendered.
-
-          * :py:attr:`~term_image.renderable.Seek.START`, the value of this field
-            may be:
-
-            * **zero**, denoting that the stream should be seeked to its beginning
-              and then the first frame should be rendered.
-            * **positive**, denoting that the stream should be seeked to the
-              (:py:attr:`frame_offset`)th frame **after the first** and then the new
-              next frame should be rendered.
-
-          * :py:attr:`~term_image.renderable.Seek.END`, the value of this field
-            may be:
-
-            * **zero**, denoting that the stream should be seeked to its end
-              and then the last frame should be rendered.
-            * **negative**, denoting that the stream should be seeked to the
-              (-:py:attr:`frame_offset`)th frame **before the last** and then the new
-              next frame should be rendered.
-
-            If the end of the stream cannot be determined (yet), such as with a live
-            source, the furthest available frame in the **forward** direction should
-            be taken to be the end.
-
-          .. note::
-             * If any seek operation is not supported by the underlying source, it
-               should be ignored and the next frame on the stream should be rendered.
-             * If forward seek is supported but the offset is out of the range of
-               available frames, the stream should be seeked to the furthest available
-               frame in the forward direction if its end cannot be determined (yet),
-               such as with a live source.
-               Otherwise i.e if the offset is determined to be beyond the end of the
-               stream, :py:class:`StopIteration` should be raised
-               (see :py:meth:`~term_image.renderable.Renderable._render_`).
-             * If backward seek is supported but the offset is out of the range of
-               available frames, the stream should be seeked to its beginning or the
-               furthest available frame in the backward direction.
-
-          .. tip::
-             A :term:`render class` that implements
-             :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` frame count should
-             specify which seek operations it supports and any necessary details.
-        """
-
-        seek_whence: Seek
-        """Reference position for :py:attr:`frame_offset`
-
-        If the :py:attr:`~term_image.renderable.Renderable.frame_count` of the
-        renderable (that generated the data) is *definite*, or
-        :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` but
-        :py:attr:`iteration` is ``False``; the value of this
-        field is always :py:attr:`~term_image.renderable.Seek.START`.
-        Otherwise i.e if :py:attr:`~term_image.renderable.Renderable.frame_count`
-        is :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` and
-        :py:attr:`iteration` is ``True``, it may be any member of
-        :py:class:`~term_image.renderable.Seek`.
-        """
-
-        duration: int | FrameDuration | None
-        """Frame duration
-
-        The possible values and their interpretation are the same as for
-        :py:attr:`~term_image.renderable.Renderable.frame_duration`.
-        See :py:meth:`~term_image.renderable.Renderable._render_`.
-        """
-
-        iteration: bool
-        """:term:`Render` operation kind
-
-        ``True`` if the render is part of a render operation involving a sequence of
-        renders (most likely of different frames). Otherwise i.e if it's a one-off
-        render, ``False``.
-        """
-
-
+# NOTE: The position of these assignments is critical, as they're required for the
+# creation of render argument and data namespace classes.
 _types.Renderable = Renderable
 _types.RenderableMeta = RenderableMeta
 _types.BASE_RENDER_ARGS.__init__(Renderable)
+
+
+class RenderableData(DataNamespace, render_cls=Renderable):
+    """RenderableData()
+
+    Render data namespace for :py:class:`~term_image.renderable.Renderable`.
+
+    .. seealso::
+
+       :py:attr:`~term_image.renderable.Renderable._Data_`
+          Render class-specific render data.
+
+       :py:meth:`~term_image.renderable.Renderable._render_`
+          Renders a frame of a renderable.
+    """
+
+    size: geometry.Size
+    """:term:`Render size`
+
+    See :py:meth:`~term_image.renderable.Renderable._render_`.
+    """
+
+    frame_offset: int
+    """Frame number/offset
+
+    If the :py:attr:`~term_image.renderable.Renderable.frame_count` of the
+    renderable (that generated the data) is:
+
+    * *definite* (i.e an integer); the value of this field is a **non-negative**
+      integer **less than the frame count**, the number of the frame to be rendered.
+    * :py:attr:`~term_image.renderable.FrameCount.INDEFINITE`, the value range and
+      interpretation of this field depends on the value of :py:attr:`iteration`
+      and :py:attr:`seek_whence`.
+
+      If :py:attr:`iteration` is ``False``, the value is always **zero** and
+      anything (such as a placeholder frame) may be rendered, as renderables with
+      :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` frame count are
+      typically meant for iteration/animation.
+
+      If :py:attr:`iteration` is ``True`` and :py:attr:`seek_whence` is:
+
+      * :py:attr:`~term_image.renderable.Seek.CURRENT`, the value of this field
+        may be:
+
+        * **zero**, denoting that the next frame on the stream should be rendered.
+        * **positive**, denoting that the stream should be seeked **forward** by
+          :py:attr:`frame_offset` frames and then the new next frame should be
+          rendered.
+        * **negative**, denoting that the stream should be seeked **backward** by
+          -:py:attr:`frame_offset` frames and then the new next frame should be
+          rendered.
+
+      * :py:attr:`~term_image.renderable.Seek.START`, the value of this field
+        may be:
+
+        * **zero**, denoting that the stream should be seeked to its beginning
+          and then the first frame should be rendered.
+        * **positive**, denoting that the stream should be seeked to the
+          (:py:attr:`frame_offset`)th frame **after the first** and then the new
+          next frame should be rendered.
+
+      * :py:attr:`~term_image.renderable.Seek.END`, the value of this field
+        may be:
+
+        * **zero**, denoting that the stream should be seeked to its end
+          and then the last frame should be rendered.
+        * **negative**, denoting that the stream should be seeked to the
+          (-:py:attr:`frame_offset`)th frame **before the last** and then the new
+          next frame should be rendered.
+
+        If the end of the stream cannot be determined (yet), such as with a live
+        source, the furthest available frame in the **forward** direction should
+        be taken to be the end.
+
+      .. note::
+         * If any seek operation is not supported by the underlying source, it
+           should be ignored and the next frame on the stream should be rendered.
+         * If forward seek is supported but the offset is out of the range of
+           available frames, the stream should be seeked to the furthest available
+           frame in the forward direction if its end cannot be determined (yet),
+           such as with a live source.
+           Otherwise i.e if the offset is determined to be beyond the end of the
+           stream, :py:class:`StopIteration` should be raised
+           (see :py:meth:`~term_image.renderable.Renderable._render_`).
+         * If backward seek is supported but the offset is out of the range of
+           available frames, the stream should be seeked to its beginning or the
+           furthest available frame in the backward direction.
+
+      .. tip::
+         A :term:`render class` that implements
+         :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` frame count should
+         specify which seek operations it supports and any necessary details.
+    """
+
+    seek_whence: Seek
+    """Reference position for :py:attr:`frame_offset`
+
+    If the :py:attr:`~term_image.renderable.Renderable.frame_count` of the
+    renderable (that generated the data) is *definite*, or
+    :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` but
+    :py:attr:`iteration` is ``False``; the value of this
+    field is always :py:attr:`~term_image.renderable.Seek.START`.
+    Otherwise i.e if :py:attr:`~term_image.renderable.Renderable.frame_count`
+    is :py:attr:`~term_image.renderable.FrameCount.INDEFINITE` and
+    :py:attr:`iteration` is ``True``, it may be any member of
+    :py:class:`~term_image.renderable.Seek`.
+    """
+
+    duration: int | FrameDuration | None
+    """Frame duration
+
+    The possible values and their interpretation are the same as for
+    :py:attr:`~term_image.renderable.Renderable.frame_duration`.
+    See :py:meth:`~term_image.renderable.Renderable._render_`.
+    """
+
+    iteration: bool
+    """:term:`Render` operation kind
+
+    ``True`` if the render is part of a render operation involving a sequence of
+    renders (most likely of different frames). Otherwise i.e if it's a one-off
+    render, ``False``.
+    """

--- a/src/term_image/renderable/_renderable.py
+++ b/src/term_image/renderable/_renderable.py
@@ -119,6 +119,151 @@ class Renderable(metaclass=RenderableMeta, _base=True):
 
     # Class Attributes =========================================================
 
+    # Initialized by `RenderableMeta` and may be updated by `ArgsNamespaceMeta`
+    Args: ClassVar[type[ArgsNamespace] | None]
+    """:term:`Render class`\\ -specific render arguments.
+
+    This is either:
+
+    - a render argument namespace class (subclass of :py:class:`ArgsNamespace`)
+      associated [#ran1]_ with the render class, or
+    - :py:data:`None`, if the render class has no render arguments.
+
+    If this is a class, an instance of it (or a subclass thereof) is contained within
+    any :py:class:`RenderArgs` instance associated [#ra2]_ with the render class or
+    any of its subclasses. Also, an instance of this class (or a subclass of it) is
+    returned by :py:meth:`render_args[render_cls]
+    <term_image.renderable.RenderArgs.__getitem__>`; where *render_args* is
+    an instance of :py:class:`~term_image.renderable.RenderArgs` as previously
+    described and *render_cls* is the render class with which this namespace class
+    is associated [#ran1]_.
+
+    .. collapse:: Example
+
+       >>> class Foo(Renderable):
+       ...     pass
+       ...
+       ... class FooArgs(ArgsNamespace, render_cls=Foo):
+       ...     foo: str | None = None
+       ...
+       >>> Foo.Args is FooArgs
+       True
+       >>>
+       >>> # default
+       >>> foo_args = Foo.Args()
+       >>> foo_args
+       FooArgs(foo=None)
+       >>> foo_args.foo is None
+       True
+       >>>
+       >>> render_args = RenderArgs(Foo)
+       >>> render_args[Foo]
+       FooArgs(foo=None)
+       >>>
+       >>> # non-default
+       >>> foo_args = Foo.Args("FOO")
+       >>> foo_args
+       FooArgs(foo='FOO')
+       >>> foo_args.foo
+       'FOO'
+       >>>
+       >>> render_args = RenderArgs(Foo, foo_args.update(foo="bar"))
+       >>> render_args[Foo]
+       FooArgs(foo='bar')
+
+    On the other hand, if this is :py:data:`None`, it implies the render class has no
+    render arguments.
+
+    .. collapse:: Example
+
+       >>> class Bar(Renderable):
+       ...     pass
+       ...
+       >>> Bar.Args is None
+       True
+       >>> render_args = RenderArgs(Bar)
+       >>> render_args[Bar]
+       Traceback (most recent call last):
+         ...
+       NoArgsNamespaceError: 'Bar' defines no render arguments
+    """
+
+    # Initialized by `RenderableMeta` and may be updated by `DataNamespaceMeta`
+    _Data_: ClassVar[type[DataNamespace] | None]
+    """:term:`Render class`\\ -specific render data.
+
+    This is either:
+
+    - a render data namespace class (subclass of :py:class:`DataNamespace`)
+      associated [#rdn1]_ with the render class, or
+    - :py:data:`None`, if the render class has no render data.
+
+    If this is a class, an instance of it (or a subclass thereof) is contained within
+    any :py:class:`RenderData` instance associated [#rd1]_ with the render class or
+    any of its subclasses. Also, an instance of this class (or a subclass of it) is
+    returned by :py:meth:`render_data[render_cls]
+    <term_image.renderable.RenderData.__getitem__>`; where *render_data* is
+    an instance of :py:class:`~term_image.renderable.RenderData` as previously
+    described and *render_cls* is the render class with which this namespace class
+    is associated [#rdn1]_.
+
+    .. collapse:: Example
+
+       >>> class Foo(Renderable):
+       ...     pass
+       ...
+       ... class _Data_(DataNamespace, render_cls=Foo):
+       ...     foo: str | None
+       ...
+       >>> Foo._Data_ is FooData
+       True
+       >>>
+       >>> foo_data = Foo._Data_()
+       >>> foo_data
+       <FooData: foo=<uninitialized>>
+       >>> foo_data.foo
+       Traceback (most recent call last):
+         ...
+       UninitializedDataFieldError: The render data field 'foo' of 'Foo' has not \
+been initialized
+       >>>
+       >>> foo_data.foo = "FOO"
+       >>> foo_data
+       <FooData: foo='FOO'>
+       >>> foo_data.foo
+       'FOO'
+       >>>
+       >>> render_data = RenderData(Foo)
+       >>> render_data[Foo]
+       <FooData: foo=<uninitialized>>
+       >>>
+       >>> render_data[Foo].foo = "bar"
+       >>> render_data[Foo]
+       <FooData: foo='bar'>
+
+    On the other hand, if this is :py:data:`None`, it implies the render class has no
+    render data.
+
+    .. collapse:: Example
+
+       >>> class Bar(Renderable):
+       ...     pass
+       ...
+       >>> Bar._Data_ is None
+       True
+       >>>
+       >>> render_data = RenderData(Bar)
+       >>> render_data[Bar]
+       Traceback (most recent call last):
+         ...
+       NoDataNamespaceError: 'Bar' defines no render data
+
+    .. seealso::
+
+       :py:class:`~term_image.renderable.RenderableData`
+          Render data for :py:class:`~term_image.renderable.Renderable`.
+    """
+
     _EXPORTED_ATTRS_: ClassVar[tuple[str]]
     """Exported attributes.
 

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -137,8 +137,8 @@ class ArgsDataNamespaceMeta(type):
                 if fields:
                     raise RenderArgsDataError("Cannot both inherit and define fields")
             elif fields:
-                for name in fields:
-                    namespace.pop(name, None)
+                for field_name in fields:
+                    namespace.pop(field_name, None)
                 namespace["_FIELDS"] = MappingProxyType(dict.fromkeys(fields))
 
             namespace["__slots__"] = tuple(fields)

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -290,9 +290,8 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta):
 
         if len(values) > len(default_fields):
             raise TypeError(
-                f"{type(self)._RENDER_CLS.__name__!r} defines "
-                f"{len(default_fields)} render argument field(s) but "
-                f"{len(values)} values were given"
+                f"{type(self).__name__!r} defines {len(default_fields)} render "
+                f"argument field(s) but {len(values)} values were given"
             )
         value_fields = dict(zip(default_fields, values))
 

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -576,13 +576,13 @@ class DataNamespace(ArgsDataNamespace, metaclass=DataNamespaceMeta):
 
     Subclassing, defining (and inheriting) fields and associating with a render
     class are just as they are for :ref:`args-namespace`, except that values
-    assigned to the class attributes are not used.
+    assigned to class attributes are neither required nor used.
 
-    Every field is **uninitialized** immediately after instantiation of a
-    namespace. The fields are expected to be initialized within the
+    Every field of a namespace is **uninitialized** immediately after instantiation.
+    The fields are expected to be initialized within the
     :py:meth:`~term_image.renderable.Renderable._get_render_data_` method of the
-    render class with which the namespace is associated [#rdn1]_ or at some other point
-    during a render operation, if necessary.
+    render class with which the namespace is associated [#rdn1]_ or at some other
+    point during a render operation, if necessary.
 
     NOTE:
         * Fields are exposed as instance attributes.
@@ -790,7 +790,8 @@ class RenderArgs(RenderArgsData):
         IncompatibleArgsNamespaceError: Incompatible [#ran2]_ render argument namespace.
 
     A set of render arguments (an instance of this class) is basically a container of
-    render argument namespaces (instances of :py:class:`RenderArgs.Namespace`); one for
+    render argument namespaces (instances of
+    :py:class:`~term_image.renderable.ArgsNamespace`); one for
     each :term:`render class`, which defines render arguments, in the Method Resolution
     Order of its associated [#ra2]_ render class.
 
@@ -804,10 +805,10 @@ class RenderArgs(RenderArgsData):
     NOTE:
         Instances are immutable but updated copies can be created via :py:meth:`update`.
 
-    TIP:
-        See the ``Args`` attribute (subclass of :py:class:`RenderArgs.Namespace`)
-        of :term:`render classes`, if not ``None``, for their respective render
-        argument namespaces.
+    .. seealso::
+
+       :py:attr:`~term_image.renderable.Renderable.Args`
+          Render class-specific render arguments.
 
     .. Completed in /docs/source/api/renderable.rst
     """
@@ -1116,8 +1117,8 @@ class RenderArgs(RenderArgsData):
         Propagates exceptions raised by:
 
         * the class constructor, for the **first** form.
-        * :py:meth:`__getitem__` and :py:meth:`RenderArgs.Namespace.update`, for the
-          **second** form.
+        * :py:meth:`__getitem__` and :py:meth:`ArgsNamespace.update()
+          <term_image.renderable.ArgsNamespace.update>`, for the **second** form.
         """
         if isinstance(render_cls_or_namespace, RenderableMeta):
             if namespaces:
@@ -1153,9 +1154,9 @@ class RenderData(RenderArgsData):
         render_cls: A :term:`render class`.
 
     An instance of this class is basically a container of render data namespaces
-    (instances of :py:class:`RenderData.Namespace`); one for each :term:`render class`,
-    which defines render data, in the Method Resolution Order of its associated
-    [#rd1]_ render class.
+    (instances of :py:class:`~term_image.renderable.DataNamespace`); one for each
+    :term:`render class`, which defines render data, in the Method Resolution Order
+    of its associated [#rd1]_ render class.
 
     NOTE:
         * Instances are immutable but the constituent namespaces are mutable.
@@ -1164,10 +1165,10 @@ class RenderData(RenderArgsData):
         * Instances should always be explicitly finalized as soon as they're no longer
           needed.
 
-    TIP:
-        See the ``_Data_`` attribute (subclass of :py:class:`RenderData.Namespace`)
-        of :term:`render classes`, if not ``None``, for their respective render
-        data namespaces.
+    .. seealso::
+
+       :py:attr:`~term_image.renderable.Renderable._Data_`
+          Render class-specific render data.
     """
 
     # Class Attributes =========================================================

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -464,11 +464,10 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta):
             A dictionary mapping field names to their values.
 
         WARNING:
-            The number and order of fields is guaranteed to be the same for a
-            subclass that defines fields, its subclasses (that inherit its fields)
-            and all their instances but beyond this, should not be relied upon as
-            the details (such as the specific number or order) may change without
-            notice.
+            The number and order of fields are guaranteed to be the same for a
+            namespace class that defines fields, its subclasses, and all their
+            instances; but beyond this, should not be relied upon as the details
+            (such as the specific number or order) may change without notice.
 
             The order is an implementation detail of the Render Arguments/Data API
             and the number should be considered an implementation detail of the
@@ -484,11 +483,10 @@ class ArgsNamespace(ArgsDataNamespace, metaclass=ArgsNamespaceMeta):
             A mapping of field names to their default values.
 
         WARNING:
-            The number and order of fields is guaranteed to be the same for a
-            subclass that defines fields, its subclasses (that inherit its fields)
-            and all their instances but beyond this, should not be relied upon as
-            the details (such as the specific number or order) may change without
-            notice.
+            The number and order of fields are guaranteed to be the same for a
+            namespace class that defines fields, its subclasses, and all their
+            instances; but beyond this, should not be relied upon as the details
+            (such as the specific number or order) may change without notice.
 
             The order is an implementation detail of the Render Arguments/Data API
             and the number should be considered an implementation detail of the
@@ -648,11 +646,10 @@ class DataNamespace(ArgsDataNamespace, metaclass=DataNamespaceMeta):
           UninitializedDataFieldError: A field has not been initialized.
 
         WARNING:
-            The number and order of fields is guaranteed to be the same for a
-            subclass that defines fields, its subclasses (that inherit its fields)
-            and all their instances but beyond this, should not be relied upon as
-            the details (such as the specific number or order) may change without
-            notice.
+            The number and order of fields are guaranteed to be the same for a
+            namespace class that defines fields, its subclasses, and all their
+            instances; but beyond this, should not be relied upon as the details
+            (such as the specific number or order) may change without notice.
 
             The order is an implementation detail of the Render Arguments/Data API
             and the number should be considered an implementation detail of the
@@ -668,11 +665,10 @@ class DataNamespace(ArgsDataNamespace, metaclass=DataNamespaceMeta):
             A tuple of field names.
 
         WARNING:
-            The number and order of fields is guaranteed to be the same for a
-            subclass that defines fields, its subclasses (that inherit its fields)
-            and all their instances but beyond this, should not be relied upon as
-            the details (such as the specific number or order) may change without
-            notice.
+            The number and order of fields are guaranteed to be the same for a
+            namespace class that defines fields, its subclasses, and all their
+            instances; but beyond this, should not be relied upon as the details
+            (such as the specific number or order) may change without notice.
 
             The order is an implementation detail of the Render Arguments/Data API
             and the number should be considered an implementation detail of the

--- a/src/term_image/renderable/_types.py
+++ b/src/term_image/renderable/_types.py
@@ -69,13 +69,13 @@ class IncompatibleRenderArgsError(RenderArgsError):
 
 class NoArgsNamespaceError(RenderArgsError):
     """Raised when an attempt is made to get a render argument namespace for a
-    :term:`render class` that defines no render arguments.
+    :term:`render class` that has no render arguments.
     """
 
 
 class NoDataNamespaceError(RenderDataError):
     """Raised when an attempt is made to get a render data namespace for a
-    :term:`render class` that defines no render data.
+    :term:`render class` that has no render data.
     """
 
 
@@ -792,7 +792,7 @@ class RenderArgs(RenderArgsData):
     A set of render arguments (an instance of this class) is basically a container of
     render argument namespaces (instances of
     :py:class:`~term_image.renderable.ArgsNamespace`); one for
-    each :term:`render class`, which defines render arguments, in the Method Resolution
+    each :term:`render class`, which has render arguments, in the Method Resolution
     Order of its associated [#ra2]_ render class.
 
     The namespace for each render class is derived from the following sources, in
@@ -967,7 +967,7 @@ class RenderArgs(RenderArgsData):
 
         Args:
             render_cls: A :term:`render class` of which :py:attr:`render_cls` is a
-              subclass (which may be :py:attr:`render_cls` itself) and which defines
+              subclass (which may be :py:attr:`render_cls` itself) and which has
               render arguments.
 
         Returns:
@@ -976,7 +976,7 @@ class RenderArgs(RenderArgsData):
         Raises:
             TypeError: An argument is of an inappropriate type.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
-            NoArgsNamespaceError: *render_cls* defines no render arguments.
+            NoArgsNamespaceError: *render_cls* has no render arguments.
         """
         try:
             return self._namespaces[render_cls]
@@ -986,7 +986,7 @@ class RenderArgs(RenderArgsData):
 
             if issubclass(self.render_cls, render_cls):
                 raise NoArgsNamespaceError(
-                    f"{render_cls.__name__!r} defines no render arguments"
+                    f"{render_cls.__name__!r} has no render arguments"
                 ) from None
 
             raise ValueError(
@@ -1098,7 +1098,7 @@ class RenderArgs(RenderArgsData):
 
             render_cls (Type[Renderable]): A :term:`render class` of which
               :py:attr:`render_cls` is a subclass (which may be :py:attr:`render_cls`
-              itself) and which defines render arguments.
+              itself) and which has render arguments.
             fields: Render argument fields.
 
               The keywords must be names of render argument fields for *render_cls*.
@@ -1155,7 +1155,7 @@ class RenderData(RenderArgsData):
 
     An instance of this class is basically a container of render data namespaces
     (instances of :py:class:`~term_image.renderable.DataNamespace`); one for each
-    :term:`render class`, which defines render data, in the Method Resolution Order
+    :term:`render class`, which has render data, in the Method Resolution Order
     of its associated [#rd1]_ render class.
 
     NOTE:
@@ -1203,7 +1203,7 @@ class RenderData(RenderArgsData):
 
         Args:
             render_cls: A :term:`render class` of which :py:attr:`render_cls` is a
-              subclass (which may be :py:attr:`render_cls` itself) and which defines
+              subclass (which may be :py:attr:`render_cls` itself) and which has
               render data.
 
         Returns:
@@ -1212,7 +1212,7 @@ class RenderData(RenderArgsData):
         Raises:
             TypeError: An argument is of an inappropriate type.
             ValueError: :py:attr:`render_cls` is not a subclass of *render_cls*.
-            NoDataNamespaceError: *render_cls* defines no render data.
+            NoDataNamespaceError: *render_cls* has no render data.
         """
         try:
             return self._namespaces[render_cls]
@@ -1222,7 +1222,7 @@ class RenderData(RenderArgsData):
 
             if issubclass(self.render_cls, render_cls):
                 raise NoDataNamespaceError(
-                    f"{render_cls.__name__!r} defines no render data"
+                    f"{render_cls.__name__!r} has no render data"
                 ) from None
 
             raise ValueError(

--- a/tests/render/test_iterator.py
+++ b/tests/render/test_iterator.py
@@ -9,12 +9,12 @@ from term_image.geometry import Size
 from term_image.padding import AlignedPadding, ExactPadding
 from term_image.render import FinalizedIteratorError, RenderIterator
 from term_image.renderable import (
+    DataNamespace,
     FrameCount,
     FrameDuration,
     IncompatibleRenderArgsError,
     Renderable,
     RenderArgs,
-    RenderData,
     Seek,
 )
 
@@ -89,8 +89,9 @@ class IndefiniteFrameFill(Renderable):
         )
         return render_data
 
-    class _Data_(RenderData.Namespace):
-        frames: Iterator[int] | None
+
+class IndefiniteFrameFillData(DataNamespace, render_cls=IndefiniteFrameFill):
+    frames: Iterator[int] | None
 
 
 class CacheFrameFill(FrameFill):

--- a/tests/renderable/test_types.py
+++ b/tests/renderable/test_types.py
@@ -915,7 +915,7 @@ class TestArgsNamespace:
         Namespace = Bar.Args
 
         def test_args(self):
-            with pytest.raises(TypeError, match="'Bar' defines 3 .* 4 .* given"):
+            with pytest.raises(TypeError, match="'BarArgs' defines 3 .* 4 .* given"):
                 self.Namespace("", "", "", "")
 
             with pytest.raises(UnknownArgsFieldError, match="'dude'"):


### PR DESCRIPTION
- Fixes render argument/data namespace class names.
- Redesigns namespaces classes.
- Delegates association of namespace classes to their metaclasses instead of `RenderableMeta`.
- Simplifies the collection of render argument/data namespaces of parent render classes in `RenderableMeta`.
- Drops the use of inner class definitions.

  - `Renderable._Data_` -> `RenderableData`.
  - `RenderArgs.Namespace` -> `ArgsNamespace`.
  - `RenderData.Namespace` -> `DataNamespace`.

  In `.renderable._types`:

  - `RenderArgsData._NamespaceMeta` -> `ArgsDataNamespaceMeta`.
  - `RenderArgsData.Namespace` -> `ArgsDataNamespace`.
  - `RenderArgs._NamespaceMeta` -> `ArgsNamespaceMeta`.

- Adds `.renderable._types.DataNamespaceMeta`.
- Updates documentation for render argument and data namespaces.
- Updates tests related to render argument and data namespaces.
- Updates definitions of render argument and data namespaces across the tests.

- - -

Required for the advancement of #100.

From a dynamic typing perspective, both the current and new APIs are equally good but the current will not work with static typing.

The new API happens to have a couple minor downsides though:

1. If a `RenderArgs(render_cls)` is created before an argument namespace class is associated with `render_cls`, that `RenderArgs` instance will lack a namespace for `render_cls`, unlike those created afterwards.
2. If `render_cls` is subclassed before an argument namespace class is associated with `render_cls`, every `RenderArgs` instance associated with that subclass will lack a namespace for `render_cls`.

The same applies to render data... but looking on the bright side, this typically shouldn't occur and there's an admonition in the docs concerning this.