### PR TITLE
Initialize variables correctly in utils.py get_cell_size

### DIFF
--- a/src/term_image/utils.py
+++ b/src/term_image/utils.py
@@ -412,7 +412,9 @@ def get_cell_size() -> term_image.geometry.Size | None:
     text_area_size: tuple[int, ...]
     cell_size = text_area_size = (0, 0)
     got_text_area_size = False
-
+    cell_size_match = False
+    text_area_size_match = False
+    
     # If a thread reaches this point while the lock is being changed
     # (the old lock has been acquired but hasn't been changed), after the lock has
     # been changed and the former lock is released, the waiting thread will acquire


### PR DESCRIPTION
I am using term-image within toot

- queries disabled
- forcing iterm2 image rendering protocol
- using what I think is the hterm.js terminal emulator (which claims to support iterm2 image rendering protocol) - it's the terminal embedded in the Google Cloud Shell webpage.  There's a possiblity it might be xterm.js, which does not support iterm2 protocol natively.

Without this PR applied, there are code paths through get_cell_size(...) that reference uninitialized variables. 
