### PR TITLE
feat: Allow ghostty to render kitty images

### DIFF
--- a/src/term_image/image/kitty.py
+++ b/src/term_image/image/kitty.py
@@ -228,6 +228,8 @@ class KittyImage(GraphicsImage):
     _TERM_VERSION: str = ""
     _KITTY_VERSION: Tuple[int, int, int] = ()
 
+    _terminals = ["konsole", "ghostty"]
+
     @classmethod
     def clear(
         cls, *, cursor: bool = False, z_index: Optional[int] = None, now: bool = False
@@ -328,7 +330,7 @@ class KittyImage(GraphicsImage):
                             cls._KITTY_VERSION = version_tuple
                             cls._supported = True
                 # Konsole is good as long as it responds to the graphics query
-                elif name == "konsole":
+                elif name in self._terminals:
                     cls._TERM, cls._TERM_VERSION = name, version or ""
                     cls._supported = True
 

--- a/src/term_image/widget/_urwid.py
+++ b/src/term_image/widget/_urwid.py
@@ -74,6 +74,8 @@ class UrwidImage(urwid.Widget):
     # from -(2**31)
     _ti_next_z_index = 1
 
+    _terminals = ["konsole", "ghostty"]
+
     def __init__(
         self, image: BaseImage, format_spec: str = "", *, upscale: bool = False
     ) -> None:
@@ -102,7 +104,7 @@ class UrwidImage(urwid.Widget):
             # Since Konsole doesn't blend images placed at the same location and
             # z-index, unlike Kitty (and potentially others), `blend=True` is
             # better on Konsole as it reduces/eliminates flicker.
-            if get_terminal_name_version()[0] != "konsole":
+            if get_terminal_name_version()[0] not in self._terminals:
                 # To clear directly overlapped images when urwid redraws a line without
                 # a change in image position
                 style_args["blend"] = False
@@ -405,7 +407,7 @@ class UrwidImageCanvas(urwid.Canvas):
                 * (
                     isinstance(image, KittyImage)
                     or isinstance(image, ITerm2Image)
-                    and get_terminal_name_version()[0] == "konsole"
+                    and get_terminal_name_version()[0] in self._terminals
                 )
             )
             for line in self._ti_lines[trim_top : -trim_bottom or None]:
@@ -617,7 +619,7 @@ class UrwidImageScreen(urwid.raw_display.Screen):
             KittyImage.forced_support
             or KittyImage.is_supported()
             or ITerm2Image.is_supported()
-            and get_terminal_name_version()[0] == "konsole"
+            and get_terminal_name_version()[0] in self._terminals
         ):
             return
 
@@ -659,7 +661,7 @@ class UrwidImageScreen(urwid.raw_display.Screen):
                         if (
                             isinstance(widget._ti_image, KittyImage)
                             or isinstance(widget._ti_image, ITerm2Image)
-                            and get_terminal_name_version()[0] == "konsole"
+                            and get_terminal_name_version()[0] in self._terminals
                         ):
                             image_cviews.add((canv, row, col, *trim, cols, rows))
 


### PR DESCRIPTION
![toot-term-image](https://github.com/AnonymouX47/term-image/assets/7937/69b9bf78-76ac-427a-8348-3bc204f1e9f7)

Using [toot](https://github.com/ihabunek/toot) in [Ghostty](https://mitchellh.com/ghostty), I found that images were supported but not rendering correctly; one part was missing. I figured that Konsole had special features enabled/disabled, so I added Ghostty to the exceptions. After some tests, the images rendered correctly.

I know Ghostty is in beta and might change. Feel free to clean up this PR or close it if you feel so. I can patch `term-image` manually until Ghostty becomes public.